### PR TITLE
Remove gwas conditional initialization from internal config.

### DIFF
--- a/transmartApp/grails-app/conf/application.groovy
+++ b/transmartApp/grails-app/conf/application.groovy
@@ -27,7 +27,6 @@ if (!Environment.isWarDeployed() && Environment.isWithinShell()) {
 org.transmart.originalConfigBinding = getBinding()
 
 org.transmartproject.app.oauthEnabled = true
-org.transmartproject.app.gwavaEnabled = false
 org.transmartproject.app.transmartURL = "http://localhost:${System.getProperty('server.port', '8080')}"
 
 
@@ -240,12 +239,6 @@ grails { plugin { springsecurity {
                 [pattern: '/oauth/token.dispatch', access: ["isFullyAuthenticated() and (request.getMethod().equals('GET') or request.getMethod().equals('POST'))"]],
         ]
 
-        // This looks dangerous and it possibly is (would need to check), but
-        // reflects the instructions I got from the developer.
-        def gwavaMappings = [
-                [pattern: '/gwasWeb/**', access: ['IS_AUTHENTICATED_ANONYMOUSLY']],
-        ]
-
         interceptUrlMap = [
                 [pattern: '/login/**',                   access: ['IS_AUTHENTICATED_ANONYMOUSLY']],
                 [pattern: '/js/**',                      access: ['IS_AUTHENTICATED_ANONYMOUSLY']],
@@ -267,10 +260,11 @@ grails { plugin { springsecurity {
                 [pattern: '/authUserSecureAccess/**',    access: ['ROLE_ADMIN']],
                 [pattern: '/secureObjectPath/**',        access: ['ROLE_ADMIN']],
                 [pattern: '/userGroup/**',               access: ['ROLE_ADMIN']],
+                //TODO This looks dangerous. It opens acess to the gwas data for everybody.
+                [pattern: '/gwasWeb/**',                 access: ['IS_AUTHENTICATED_ANONYMOUSLY']],
                 [pattern: '/secureObjectAccess/**',      access: ['ROLE_ADMIN']]
         ] +
                 (org.transmartproject.app.oauthEnabled ?  oauthEndpoints : []) +
-                (org.transmartproject.app.gwavaEnabled ?  gwavaMappings : []) +
                 [
                         [pattern: '/**',                         access: ['IS_AUTHENTICATED_REMEMBERED']], // must be last
                 ]


### PR DESCRIPTION
We have two types of configurations: internal and external.
Internal configuration is part of application.
The source code of it can be found here `transmartApp/grail-app/conf/application.groovy`.
External configuration files (`Config.groovy`, `DataSource.groovy` as legacy way or `application.groovy`) are located under `~/.grails/transmartConfig/` directory.
Where `~` is a home directory of the user who runs the application.

The order of applying these configuration files as follows:

internal `application.groovy`
externals
        `Config.groovy`
        `DataSource.groovy`
        `application.groovy`

The configuration file that goes later could override settings set by previous ones.
It becomes harder to reason about such overrides when there is logic that depends on the flags in the configuration files.