### PR TITLE
Add missing GET /v2/patient_sets/{resultInstanceId} call description to swagger doc

### DIFF
--- a/open-api/README.md
+++ b/open-api/README.md
@@ -18,12 +18,12 @@ You can open the UI [locally](index.html), or visit a
 
 To generate `swagger.json` and `swagger_spec.js` from `swagger.yaml`, run:
 ```bash
-js-yml swagger.yaml > swagger.json
+js-yaml swagger.yaml > swagger.json
 { echo -n "var spec = "; cat swagger.json; echo ";"; } > swagger_spec.js
 ```
 
-The `js-yml` tool can be obtained by:
+The `js-yaml` tool can be obtained by:
 
 ```bash
-npm -g install js-yml
+npm -g install js-yaml
 ```

--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -996,33 +996,31 @@
           "200": {
             "description": "an object with the created patient_set or error.\n",
             "schema": {
-              "type": "object",
-              "properties": {
-                "description": {
-                  "type": "string"
-                },
-                "errorMessage": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "setSize": {
-                  "type": "integer"
-                },
-                "status": {
-                  "type": "string"
-                },
-                "username": {
-                  "type": "string"
-                },
-                "requestConstraints": {
-                  "type": "string"
-                },
-                "apiVersion": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/patient_set"
+            }
+          }
+        }
+      }
+    },
+    "/v2/patient_sets/{resultInstanceId}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "resultInstanceId",
+            "in": "path",
+            "description": "ID of the patient set, called resultInstance ID because internally it refers to the result of a query\n",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "v2"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns one patient_set.\n",
+            "schema": {
+              "$ref": "#/definitions/patient_set"
             }
           }
         }
@@ -1970,6 +1968,35 @@
           "type": "string"
         },
         "trial": {
+          "type": "string"
+        }
+      }
+    },
+    "patient_set": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "errorMessage": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "setSize": {
+          "type": "integer"
+        },
+        "status": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "requestConstraints": {
+          "type": "string"
+        },
+        "apiVersion": {
           "type": "string"
         }
       }

--- a/open-api/swagger.yaml
+++ b/open-api/swagger.yaml
@@ -937,24 +937,24 @@ paths:
           description: |
             an object with the created patient_set or error.
           schema:
-            type: object
-            properties:
-              description:
-                type: string
-              errorMessage:
-                type: string
-              id:
-                type: integer
-              setSize:
-                type: integer
-              status:
-                type: string
-              username:
-                type: string
-              requestConstraints:
-                type: string
-              apiVersion:
-                type: string
+            $ref: '#/definitions/patient_set'
+  /v2/patient_sets/{resultInstanceId}:
+    get:
+      parameters:
+        - name: resultInstanceId
+          in: path
+          description: |
+            ID of the patient set, called resultInstance ID because internally it refers to the result of a query
+          required: true
+          type: string
+      tags:
+        - v2
+      responses:
+        200:
+          description: |
+            Returns one patient_set.
+          schema:
+            $ref: '#/definitions/patient_set'
   /v2/tree_nodes:
     get:
       description: |
@@ -1599,6 +1599,26 @@ definitions:
         type: string
       trial:
         type: string
+  
+  patient_set:
+    type: object
+    properties:
+      description:
+        type: string
+      errorMessage:
+        type: string
+      id:
+        type: integer
+      setSize:
+        type: integer
+      status:
+        type: string
+      username:
+        type: string
+      requestConstraints:
+        type: string
+      apiVersion:
+        type: string  
   
   observation:
     type: object

--- a/open-api/swagger_spec.js
+++ b/open-api/swagger_spec.js
@@ -996,33 +996,31 @@ var spec = {
           "200": {
             "description": "an object with the created patient_set or error.\n",
             "schema": {
-              "type": "object",
-              "properties": {
-                "description": {
-                  "type": "string"
-                },
-                "errorMessage": {
-                  "type": "string"
-                },
-                "id": {
-                  "type": "integer"
-                },
-                "setSize": {
-                  "type": "integer"
-                },
-                "status": {
-                  "type": "string"
-                },
-                "username": {
-                  "type": "string"
-                },
-                "requestConstraints": {
-                  "type": "string"
-                },
-                "apiVersion": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/patient_set"
+            }
+          }
+        }
+      }
+    },
+    "/v2/patient_sets/{resultInstanceId}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "resultInstanceId",
+            "in": "path",
+            "description": "ID of the patient set, called resultInstance ID because internally it refers to the result of a query\n",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "v2"
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns one patient_set.\n",
+            "schema": {
+              "$ref": "#/definitions/patient_set"
             }
           }
         }
@@ -1970,6 +1968,35 @@ var spec = {
           "type": "string"
         },
         "trial": {
+          "type": "string"
+        }
+      }
+    },
+    "patient_set": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "errorMessage": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "setSize": {
+          "type": "integer"
+        },
+        "status": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "requestConstraints": {
+          "type": "string"
+        },
+        "apiVersion": {
           "type": "string"
         }
       }

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/PatientQueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/PatientQueryController.groovy
@@ -163,7 +163,7 @@ class PatientQueryController extends AbstractQueryController {
 
         response.status = 201
         render new QueryResultWrapper(
-                apiVersion: apiVersion,
+                apiVersion: currentVersion,
                 queryResult: patientSet,
                 requestConstraints: bodyJson
         ) as JSON


### PR DESCRIPTION
+ small fix for displayed api version in 'POST /v2/patient_Set' result