### PR TITLE
Categorical values aggregate

### DIFF
--- a/open-api/swagger.yaml
+++ b/open-api/swagger.yaml
@@ -753,7 +753,8 @@ paths:
   /v2/observations/aggregate:
     get:
       description: |
-        Calculates and returns an aggregate value.
+        Calculates and returns an aggregate value. Supported aggregate types are 'min', 'max', 'average', and
+        'values'. The first three require numeric variables, the last one categorical variables.
       tags:
         - v2
       parameters:
@@ -765,7 +766,9 @@ paths:
         - name: type
           required: true
           in: query
-          description: 'min, max, average'
+          description: |
+            'min', 'max', 'average', or 'values'. This parameter can be specified multiple times to retrieve multiple
+             aggregates at once. The 'values' aggregate cannot be combined with the numeric aggregate types.
           type: string
       responses:
         200:
@@ -780,6 +783,11 @@ paths:
                 type: number
               average:
                 type: number
+              values:
+                type: array
+                items:
+                  type: string
+                description: A list of the distinct values for categorical variables
     post:
       description: |
         Works the same as GET, but with support for longer constraints. Use this, if the total length of the URL may be longer than the maximum length.
@@ -796,7 +804,7 @@ paths:
         - name: type
           required: true
           in: body
-          description: see GET parameters
+          description: see GET parameters. Can be either a string or an array of strings.
           type: string
       responses:
         200:

--- a/open-api/swagger.yaml
+++ b/open-api/swagger.yaml
@@ -753,7 +753,7 @@ paths:
   /v2/observations/aggregate:
     get:
       description: |
-        Calculates and returns an aggregate value. Supported aggregate types are 'min', 'max', 'average', and
+        Calculates and returns an aggregate value. Supported aggregate types are 'min', 'max', 'average', 'count', and
         'values'. The first three require numeric variables, the last one categorical variables.
       tags:
         - v2
@@ -767,8 +767,8 @@ paths:
           required: true
           in: query
           description: |
-            'min', 'max', 'average', or 'values'. This parameter can be specified multiple times to retrieve multiple
-             aggregates at once. The 'values' aggregate cannot be combined with the numeric aggregate types.
+            'min', 'max', 'average', 'count', or 'values'. This parameter can be specified multiple times to retrieve
+            multiple aggregates at once. The 'values' aggregate cannot be combined with the numeric aggregate types.
           type: string
       responses:
         200:

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/AggregateType.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/AggregateType.groovy
@@ -15,8 +15,7 @@ enum AggregateType {
     MAX,
     AVERAGE,
     COUNT,
-    VALUES,
-    NONE
+    VALUES
 
     private static final Map<String, AggregateType> mapping = values().collectEntries {
         [(it.name().toLowerCase()): it]
@@ -29,9 +28,8 @@ enum AggregateType {
     public static AggregateType forName(String name) {
         name = name.toLowerCase()
         return mapping[name] ?: {
-            // TODO(jan): Should this be an exception?
-            log.error "Unknown aggregate type: ${name}"
-            return NONE
+            throw new IllegalArgumentException("Unknown aggregate type: $name")
+            null as AggregateType // because Groovy wants a return type
         }()
     }
 }

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/AggregateType.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/AggregateType.groovy
@@ -22,6 +22,10 @@ enum AggregateType {
         [(it.name().toLowerCase()): it]
     }
 
+    public String toString() {
+        name().toLowerCase()
+    }
+
     public static AggregateType forName(String name) {
         name = name.toLowerCase()
         return mapping[name] ?: {

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/AggregateType.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/AggregateType.groovy
@@ -15,6 +15,7 @@ enum AggregateType {
     MAX,
     AVERAGE,
     COUNT,
+    VALUES,
     NONE
 
     private static final Map<String, AggregateType> mapping = values().collectEntries {
@@ -23,12 +24,10 @@ enum AggregateType {
 
     public static AggregateType forName(String name) {
         name = name.toLowerCase()
-        if (mapping.containsKey(name)) {
-            return mapping[name]
-        } else {
+        return mapping[name] ?: {
             // TODO(jan): Should this be an exception?
             log.error "Unknown aggregate type: ${name}"
             return NONE
-        }
+        }()
     }
 }

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/MultiDimensionalDataResource.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/MultiDimensionalDataResource.groovy
@@ -53,7 +53,7 @@ interface MultiDimensionalDataResource {
 
     Hypercube retrieveClinicalData(MultiDimConstraint constraint, User user)
 
-    RequestConstraintsAndVersion getPatientSetRequestConstraintsAndApiVersion(long id)
+    RequestConstraintAndVersion getPatientSetConstraint(long id)
 
-    @Immutable class RequestConstraintsAndVersion { String constraints; String version }
+    @Immutable class RequestConstraintAndVersion { String constraint; String version }
 }

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/MultiDimensionalDataResource.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/MultiDimensionalDataResource.groovy
@@ -42,7 +42,15 @@ interface MultiDimensionalDataResource {
     Long patientCount(MultiDimConstraint constraint, User user)
     Long cachedPatientCount(MultiDimConstraint constraint, User user)
 
-    def aggregate(AggregateType type, MultiDimConstraint constraint, User user)
+    /**
+     * Retrieve aggregate information
+     *
+     * @param types the list of aggregates you want
+     * @param constraint specifies which observations you want to aggregate
+     * @param user The user whose access rights to consider
+     * @return a map of aggregates. The keys are the names of the aggregates.
+     */
+    Map aggregate(List<AggregateType> types, MultiDimConstraint constraint, User user)
 
     Hypercube highDimension(
             MultiDimConstraint assayConstraint_,

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/MultiDimensionalDataResource.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/MultiDimensionalDataResource.groovy
@@ -42,7 +42,7 @@ interface MultiDimensionalDataResource {
     Long patientCount(MultiDimConstraint constraint, User user)
     Long cachedPatientCount(MultiDimConstraint constraint, User user)
 
-    Number aggregate(AggregateType type, MultiDimConstraint constraint, User user)
+    def aggregate(AggregateType type, MultiDimConstraint constraint, User user)
 
     Hypercube highDimension(
             MultiDimConstraint assayConstraint_,

--- a/transmart-core-db-tests/src/integration-test/groovy/org/transmartproject/db/multidimquery/QueryServiceSpec.groovy
+++ b/transmart-core-db-tests/src/integration-test/groovy/org/transmartproject/db/multidimquery/QueryServiceSpec.groovy
@@ -14,7 +14,6 @@ import org.transmartproject.db.multidimquery.query.*
 import org.transmartproject.db.i2b2data.ConceptDimension
 import org.transmartproject.db.i2b2data.ObservationFact
 import org.transmartproject.db.user.AccessLevelTestData
-import spock.lang.Ignore
 
 import static org.transmartproject.db.dataquery.highdim.HighDimTestData.save
 
@@ -337,57 +336,6 @@ class QueryServiceSpec extends TransmartSpecification {
 
         then:
         thrown(DataInconsistencyException)
-    }
-
-    @Ignore("Aggregates are now not limited to a single concept, any constraint is supported (though not all will make sense")
-    void "test correct conceptConstraint checker in aggregate function"() {
-        setup:
-        setupData()
-
-        def user = accessLevelTestData.users[0]
-        def fact = testData.clinicalData.facts.find { it.valueType == 'N' }
-        def conceptDimension = testData.conceptData.conceptDimensions.find { it.conceptCode == fact.conceptCode }
-
-        when:
-        def constraint = new TrueConstraint()
-        multiDimService.aggregate(AggregateType.MAX, constraint, user)
-
-        then:
-        thrown(InvalidQueryException)
-
-        when:
-        constraint = new Combination(
-                operator: Operator.AND,
-                args: [
-                        new TrueConstraint(),
-                        new ConceptConstraint(
-                                path: conceptDimension.conceptPath
-                        ),
-                        new Combination(
-                                operator: Operator.AND,
-                                args: [
-                                        new ConceptConstraint(
-                                                path: conceptDimension.conceptPath
-                                        ),
-                                        new TrueConstraint()
-                                ]
-                        )
-                ]
-        )
-
-        multiDimService.aggregate(AggregateType.MAX, constraint, user)
-
-        then:
-        thrown(InvalidQueryException)
-
-        when:
-        def firstConceptConstraint = constraint.args.find { it.class == ConceptConstraint }
-        constraint.args = constraint.args - firstConceptConstraint
-        def result = multiDimService.aggregate(AggregateType.MAX, constraint, user)
-
-        then:
-        result == 10
-
     }
 
 }

--- a/transmart-core-db-tests/src/integration-test/groovy/org/transmartproject/db/multidimquery/QueryServiceSpec.groovy
+++ b/transmart-core-db-tests/src/integration-test/groovy/org/transmartproject/db/multidimquery/QueryServiceSpec.groovy
@@ -199,8 +199,8 @@ class QueryServiceSpec extends TransmartSpecification {
         patients as Set == patients2 as Set
 
         when: "I query for patients based on saved constraints"
-        def constraintAndVersion = multiDimService.getPatientSetRequestConstraintsAndApiVersion(patientSet.id)
-        def savedPatientSetConstraint = ConstraintFactory.create(JSON.parse(constraintAndVersion.constraints) as Map)
+        def constraintAndVersion = multiDimService.getPatientSetConstraint(patientSet.id)
+        def savedPatientSetConstraint = ConstraintFactory.create(JSON.parse(constraintAndVersion.constraint) as Map)
         def patients3 = multiDimService.listPatients(savedPatientSetConstraint, accessLevelTestData.users[0])
 
         then: "I get the same set of patient as before"

--- a/transmart-core-db-tests/src/integration-test/groovy/org/transmartproject/db/multidimquery/QueryServiceSpec.groovy
+++ b/transmart-core-db-tests/src/integration-test/groovy/org/transmartproject/db/multidimquery/QueryServiceSpec.groovy
@@ -83,7 +83,7 @@ class QueryServiceSpec extends TransmartSpecification {
         }
 
         ObservationFact observationFact = clinicalTestdata.createObservationFact(
-                conceptDimension, patientDimension, clinicalTestdata.DUMMY_ENCOUNTER_ID, -1
+                conceptDimension, patientDimension, clinicalTestdata.DUMMY_ENCOUNTER_ID, obs.value
         )
 
         observationFact
@@ -228,22 +228,30 @@ class QueryServiceSpec extends TransmartSpecification {
         def query = createQueryForConcept(observationFact)
 
         when:
-        def result = multiDimService.aggregate(AggregateType.MAX, query, accessLevelTestData.users[0])
+        def result = multiDimService.aggregate([AggregateType.MAX], query, accessLevelTestData.users[0])
 
         then:
-        result == 50
+        result.max == 50
 
         when:
-        result = multiDimService.aggregate(AggregateType.MIN, query, accessLevelTestData.users[0])
+        result = multiDimService.aggregate([AggregateType.MIN], query, accessLevelTestData.users[0])
 
         then:
-        result == 10
+        result.min == 10
 
         when:
-        result = multiDimService.aggregate(AggregateType.AVERAGE, query, accessLevelTestData.users[0])
+        result = multiDimService.aggregate([AggregateType.AVERAGE], query, accessLevelTestData.users[0])
 
         then:
-        result == 30 //(10+50) / 2
+        result.average == 30 //(10+50) / 2
+
+        when:
+        result = multiDimService.aggregate([AggregateType.MIN, AggregateType.MAX, AggregateType.AVERAGE], query,
+                accessLevelTestData.users[0])
+        then:
+        result.min == 10
+        result.max == 50
+        result.average == 30
     }
 
     void "test for values aggregate"() {
@@ -264,10 +272,10 @@ class QueryServiceSpec extends TransmartSpecification {
         def query = createQueryForConcept(facts[0])
 
         when:
-        def result = multiDimService.aggregate(AggregateType.VALUES, query, accessLevelTestData.users[0])
+        def result = multiDimService.aggregate([AggregateType.VALUES], query, accessLevelTestData.users[0])
 
         then:
-        [fact.textValue, "hello", "you", "there"] as Set == result as Set
+        [fact.textValue, "hello", "you", "there"] as Set == result.values as Set
     }
 
     void "test observation count and patient count"() {
@@ -314,7 +322,7 @@ class QueryServiceSpec extends TransmartSpecification {
 
         when:
         Constraint query = createQueryForConcept(observationFact)
-        multiDimService.aggregate(AggregateType.MAX, query, accessLevelTestData.users[0])
+        multiDimService.aggregate([AggregateType.MAX], query, accessLevelTestData.users[0])
 
         then:
         thrown(DataInconsistencyException)
@@ -332,7 +340,7 @@ class QueryServiceSpec extends TransmartSpecification {
 
         when:
         Constraint query = createQueryForConcept(observationFact)
-        multiDimService.aggregate(AggregateType.MAX, query, accessLevelTestData.users[0])
+        multiDimService.aggregate([AggregateType.MAX], query, accessLevelTestData.users[0])
 
         then:
         thrown(DataInconsistencyException)

--- a/transmart-core-db/grails-app/domain/org/transmartproject/db/i2b2data/ObservationFact.groovy
+++ b/transmart-core-db/grails-app/domain/org/transmartproject/db/i2b2data/ObservationFact.groovy
@@ -119,6 +119,12 @@ class ObservationFact implements Serializable {
 
     // Separate static method so this can also be called from code that accesses the database without converting to
     // domain classes
+    //
+    // The hypercube core-db code could in principle handle null values without much trouble. The tabular core-db
+    // does not distinguish between null values and absent values (it will insert nulls when expected values are
+    // missing). Therefore the HddTabularResultHypercubeAdapter tabular-to-hypercube converter treats nulls as absent
+    // values. Also Kettle does not support loading null values. As far as I know null values are not used in the
+    // wild, so it is better to not allow them in the transmart code and fail early if a null value is found.
     @CompileStatic
     static final def observationFactValue(String valueType, String textValue, BigDecimal numberValue) {
         switch(valueType) {

--- a/transmart-core-db/grails-app/domain/org/transmartproject/db/i2b2data/ObservationFact.groovy
+++ b/transmart-core-db/grails-app/domain/org/transmartproject/db/i2b2data/ObservationFact.groovy
@@ -112,6 +112,7 @@ class ObservationFact implements Serializable {
         VisitDimension.get(new VisitDimension(patient: patient, encounterNum: encounterNum))
     }
 
+    @CompileStatic
     def getValue() {
         observationFactValue(valueType, textValue, numberValue)
     }
@@ -122,8 +123,13 @@ class ObservationFact implements Serializable {
     static final def observationFactValue(String valueType, String textValue, BigDecimal numberValue) {
         switch(valueType) {
             case TYPE_TEXT:
+                if(textValue == null) throw new DataInconsistencyException("textValue is NULL for observation with text type")
                 return textValue
             case TYPE_NUMBER:
+                if(numberValue == null) throw new DataInconsistencyException("numberValue is NULL for observation " +
+                        "with numeric type")
+                if(textValue != 'E') throw new DataInconsistencyException("textValue is not set to 'E' for " +
+                        "observation with numeric type")
                 return numberValue
             default:
                 throw new DataInconsistencyException("Unsupported database value: ObservationFact.valueType " +

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/MultidimensionalDataResourceService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/MultidimensionalDataResourceService.groovy
@@ -354,8 +354,6 @@ class MultidimensionalDataResourceService implements MultiDimensionalDataResourc
 
     Class aggregateReturnType(AggregateType at) {
         switch (at) {
-            case AggregateType.NONE:
-                throw new IllegalArgumentException("AggregateType.NONE does not have a return type")
             case AggregateType.COUNT:
                 return Long
             case AggregateType.VALUES:
@@ -369,8 +367,6 @@ class MultidimensionalDataResourceService implements MultiDimensionalDataResourc
         switch (at) {
             case AggregateType.VALUES:
                 return ObservationFact.TYPE_TEXT
-            case AggregateType.NONE:
-                throw new QueryBuilderException("Query type not supported: ${at}")
             default:
                 return ObservationFact.TYPE_NUMBER
         }

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/util/GormWorkarounds.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/util/GormWorkarounds.groovy
@@ -7,7 +7,10 @@ import groovy.transform.CompileStatic
 import org.grails.core.util.ClassPropertyFetcher
 import org.grails.datastore.mapping.query.api.QueryableCriteria
 import org.grails.orm.hibernate.query.HibernateQuery
+import org.hibernate.Criteria
+import org.hibernate.StatelessSession
 import org.hibernate.criterion.Criterion
+import org.hibernate.criterion.DetachedCriteria
 import org.hibernate.criterion.Subqueries
 import org.hibernate.engine.spi.SessionImplementor
 import org.hibernate.internal.CriteriaImpl
@@ -48,6 +51,17 @@ class GormWorkarounds {
         builder.instance.fetchSize = fetchSize
 
         builder
+    }
+
+    /*
+     * A DetachedCriteria.getExecutableCriteria that accepts a StatelessSession.
+     * This method was not implemented by Hibernate itself because the Criteria api is deprecated. (Too bad Grails is
+     * still based on it.) See https://hibernate.atlassian.net/browse/HHH-2625.
+     */
+    final static Criteria getExecutableCriteria(DetachedCriteria detachedCriteria, StatelessSession session) {
+        CriteriaImpl impl = detachedCriteria.criteriaImpl
+        impl.setSession( (SessionImplementor) session );
+        return impl;
     }
 
     /**

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/util/ScrollableResultsIterator.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/util/ScrollableResultsIterator.groovy
@@ -23,9 +23,9 @@ class ScrollableResultsIterator<T> implements Iterator<T>, Closeable {
     boolean hasNext() {
         if (hasNext == null) {
             hasNext = scrollableResults.next()
-        } else {
-            hasNext
+            if(!hasNext) close()
         }
+        hasNext
     }
 
     @Override
@@ -45,7 +45,7 @@ class ScrollableResultsIterator<T> implements Iterator<T>, Closeable {
 
     @Override
     void close() throws IOException {
-        this.scrollableResults.close()
+        if(!closed) this.scrollableResults.close()
         closed = true
     }
 

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/AbstractQueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/AbstractQueryController.groovy
@@ -108,9 +108,13 @@ abstract class AbstractQueryController implements Controller {
             return request.JSON as Map
         }
         return params.collectEntries { String k, v ->
-            if (!globalParams.contains(k))
-                [k, URLDecoder.decode(v, 'UTF-8')]
-            else [:]
+            if (!globalParams.contains(k)) {
+                if(v instanceof Object[] || v instanceof List) {
+                    [k, v.collect { URLDecoder.decode(it, 'UTF-8') }]
+                } else {
+                    [k, URLDecoder.decode(v, 'UTF-8')]
+                }
+            } else [:]
         }
     }
 }

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/PatientQueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/PatientQueryController.groovy
@@ -103,12 +103,12 @@ class PatientQueryController extends AbstractQueryController {
         User user = (User) usersResource.getUserFromUsername(currentUser.username)
 
         QueryResult patientSet = multiDimService.findPatientSet(id, user)
-        def constraintsAndVersion = multiDimService.getPatientSetRequestConstraintsAndApiVersion(patientSet.id)
+        def constraint_version = multiDimService.getPatientSetConstraint(patientSet.id)
 
         render new QueryResultWrapper(
-                apiVersion: constraintsAndVersion.constraints,
+                apiVersion: constraint_version.constraint,
                 queryResult: patientSet,
-                requestConstraints: constraintsAndVersion.version
+                requestConstraint: constraint_version.version
         ) as JSON
     }
 
@@ -165,7 +165,7 @@ class PatientQueryController extends AbstractQueryController {
         render new QueryResultWrapper(
                 apiVersion: apiVersion,
                 queryResult: patientSet,
-                requestConstraints: bodyJson
+                requestConstraint: bodyJson
         ) as JSON
     }
 

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/QueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/QueryController.groovy
@@ -168,7 +168,12 @@ class QueryController extends AbstractQueryController {
         if (constraint == null) {
             return
         }
-        def aggregateTypes = type.collect { AggregateType.forName(it as String) }
+        def aggregateTypes
+        try {
+            aggregateTypes = type.collect { AggregateType.forName(it as String) }
+        } catch (IllegalArgumentException e) {
+            throw new InvalidQueryException(e)
+        }
         User user = (User) usersResource.getUserFromUsername(currentUser.username)
         Map aggregateValues = multiDimService.aggregate(aggregateTypes, constraint, user)
         render aggregateValues as JSON

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/QueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/QueryController.groovy
@@ -153,19 +153,25 @@ class QueryController extends AbstractQueryController {
     def aggregate() {
         def args = getGetOrPostParams()
         checkParams(args, ['constraint', 'type'])
+        def type = args.type
 
-        if (!args.type) {
+        if (!type) {
             throw new InvalidArgumentsException("Type parameter is missing.")
+        }
+        if (!(type instanceof String || type instanceof List)) throw new InvalidArgumentsException(
+                "invalid type parameter (not a string or a list of strings)")
+
+        if (type instanceof String) {
+            type = [type]
         }
         Constraint constraint = bindConstraint(args.constraint)
         if (constraint == null) {
             return
         }
-        def aggregateType = AggregateType.forName(args.type as String)
+        def aggregateTypes = type.collect { AggregateType.forName(it as String) }
         User user = (User) usersResource.getUserFromUsername(currentUser.username)
-        def aggregatedValue = multiDimService.aggregate(aggregateType, constraint, user)
-        def result = [(aggregateType.name().toLowerCase()): aggregatedValue]
-        render result as JSON
+        Map aggregateValues = multiDimService.aggregate(aggregateTypes, constraint, user)
+        render aggregateValues as JSON
     }
 
     /**

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/VersionController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/VersionController.groovy
@@ -66,6 +66,7 @@ class VersionController {
                 features: [
                         'versioning',
                         'and-or-constraints',
+                        'values_aggregate',
                 ]
             ]
     ])

--- a/transmart-rest-api/grails-app/services/org/transmartproject/rest/MultidimensionalDataService.groovy
+++ b/transmart-rest-api/grails-app/services/org/transmartproject/rest/MultidimensionalDataService.groovy
@@ -49,7 +49,8 @@ class MultidimensionalDataService {
      * @param hypercube the hypercube to serialise.
      * @param format the output format. Supports JSON and PROTOBUF.
      * @param out the stream to serialise to.
-     */@CompileStatic
+     */
+    @CompileStatic
     private void serialise(Hypercube hypercube, Format format, OutputStream out) {
         HypercubeSerializer serializer
         switch (format) {

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/QueryResultSerializationHelper.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/QueryResultSerializationHelper.groovy
@@ -27,8 +27,8 @@ class QueryResultSerializationHelper extends AbstractHalOrJsonSerializationHelpe
                 new PatientWrapper(apiVersion: object.apiVersion, patient: it)
             }
         }
-        if(object.requestConstraints) {
-            map.requestConstraints = object.requestConstraints
+        if(object.requestConstraint) {
+            map.requestConstraints = object.requestConstraint
             map.apiVersion = object.apiVersion
         }
         map

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/QueryResultWrapper.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/QueryResultWrapper.groovy
@@ -5,6 +5,6 @@ import org.transmartproject.core.querytool.QueryResult
 class QueryResultWrapper {
     String apiVersion
     QueryResult queryResult
-    String requestConstraints
+    String requestConstraint
     boolean embedPatients = false
 }


### PR DESCRIPTION
Add a 'values' aggregate that finds the distinct values in a categorical variable

bonus:
- Only do sanity checks if the main aggregate query fails, that saves us 2-3 (possibly expensive) database queries
- Allow multiple aggregates in a single request, that is much more efficient if the query takes a long time
- remove AggregateType.NONE which we don't need

Closes GDB-47