### PR TITLE
Update shell script for transmart-batch.

### DIFF
--- a/transmart-batch/transmart-batch.sh
+++ b/transmart-batch/transmart-batch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-version=$(cat VERSION)
-here=$(realpath $(dirname "${0}"))
+here=$(dirname "${0}")
+version=$(cat "${here}/VERSION")
 jar="${here}/build/libs/transmart-batch-${version}.jar"
 
 # Check if the jar present


### PR DESCRIPTION
Fix the bash script to run transmart-batch to:
- Correctly run from other locations than the source directory
- Work on non-linux machines (not rely on the `realpath` command).