### PR TITLE
Fix for Grails 3.2 upgrade (transactions are now disabled by default for services)

### DIFF
--- a/Rmodules/grails-app/services/com/recomdata/asynchronous/JobResultsService.groovy
+++ b/Rmodules/grails-app/services/com/recomdata/asynchronous/JobResultsService.groovy
@@ -30,8 +30,6 @@ package com.recomdata.asynchronous
  */
 class JobResultsService {
 
-    boolean transactional = false
-
     @Delegate Map jobResults = [:].asSynchronized()
 
     boolean isJobCancelled(String jobName) {

--- a/Rmodules/grails-app/services/com/recomdata/transmart/data/association/RModulesJobProcessingService.groovy
+++ b/Rmodules/grails-app/services/com/recomdata/transmart/data/association/RModulesJobProcessingService.groovy
@@ -1,5 +1,6 @@
 package com.recomdata.transmart.data.association
 
+import grails.transaction.Transactional
 import grails.util.Holders
 import org.rosuda.REngine.REXP
 import org.rosuda.REngine.Rserve.RConnection
@@ -10,8 +11,9 @@ import org.rosuda.Rserve.*
  * This class contains methods for interacting with the R environment.
  *  
 */
+@Transactional
 class RModulesJobProcessingService {
-	static transactional = true
+
 	static scope = 'request'
 	
 	def grailsApplication

--- a/Rmodules/grails-app/services/com/recomdata/transmart/data/association/asynchronous/RModulesJobService.groovy
+++ b/Rmodules/grails-app/services/com/recomdata/transmart/data/association/asynchronous/RModulesJobService.groovy
@@ -17,6 +17,7 @@
 package com.recomdata.transmart.data.association.asynchronous
 
 import com.recomdata.transmart.util.RUtil
+import grails.transaction.Transactional
 import grails.util.Holders
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang.StringUtils
@@ -29,9 +30,9 @@ import org.rosuda.REngine.Rserve.RserveException
 
 import java.lang.reflect.UndeclaredThrowableException
 
+@Transactional
 class RModulesJobService implements Job {
 
-    static transactional = true
 	static scope = 'request'
 
     def grailsApplication = Holders.grailsApplication

--- a/Rmodules/grails-app/services/com/recomdata/transmart/util/ZipService.groovy
+++ b/Rmodules/grails-app/services/com/recomdata/transmart/util/ZipService.groovy
@@ -20,15 +20,15 @@
 
 package com.recomdata.transmart.util
 
+import grails.transaction.Transactional
 import org.apache.commons.io.IOUtils
 import org.apache.commons.lang.StringUtils
 
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 
+@Transactional
 class ZipService {
-
-    boolean transactional = true
 
     private static final int BUFFER_SIZE = 250 * 1024;
 

--- a/folder-management-plugin/grails-app/services/annotation/AmTagItemService.groovy
+++ b/folder-management-plugin/grails-app/services/annotation/AmTagItemService.groovy
@@ -1,10 +1,10 @@
 package annotation
 
 import fm.FmFolder
+import grails.transaction.Transactional
 
+@Transactional
 class AmTagItemService {
-
-    boolean transactional = true
 
     def serviceMethod() {
 

--- a/folder-management-plugin/grails-app/services/annotation/AmTagTemplateService.groovy
+++ b/folder-management-plugin/grails-app/services/annotation/AmTagTemplateService.groovy
@@ -1,8 +1,9 @@
 package annotation
 
-class AmTagTemplateService {
+import grails.transaction.Transactional
 
-    boolean transactional = true
+@Transactional
+class AmTagTemplateService {
 
     def serviceMethod() {
 

--- a/folder-management-plugin/grails-app/services/annotation/MetaDataService.groovy
+++ b/folder-management-plugin/grails-app/services/annotation/MetaDataService.groovy
@@ -1,13 +1,12 @@
 package annotation
 
+import grails.transaction.Transactional
 import org.transmart.biomart.BioData
 import org.transmart.biomart.ConceptCode
 
-
+@Transactional
 class MetaDataService {
-
-    boolean transactional = true
-
+    
     def serviceMethod() {
 
     }

--- a/folder-management-plugin/grails-app/services/fm/FmFolderService.groovy
+++ b/folder-management-plugin/grails-app/services/fm/FmFolderService.groovy
@@ -2,6 +2,7 @@ package fm
 
 import annotation.*
 import com.recomdata.util.FolderType
+import grails.transaction.Transactional
 import org.transmart.mongo.MongoUtils
 
 import grails.util.Holders
@@ -32,12 +33,11 @@ import com.mongodb.MongoClient;
 import com.mongodb.gridfs.GridFS;
 import com.mongodb.gridfs.GridFSDBFile
 
+@Transactional
 class FmFolderService {
 
     final private static DEFAULT_FILE_TYPES =
             'xml,json,csv,pdf,doc,docx,ppt,pptx,xls,xlsx,odt,odp,ods,ott,otp,ots,rtf,htm,html,txt,log'
-
-    static transactional = true
 
     def getConfig() {
         Holders.grailsApplication.config

--- a/folder-management-plugin/grails-app/services/fm/UploadFilesService.groovy
+++ b/folder-management-plugin/grails-app/services/fm/UploadFilesService.groovy
@@ -1,5 +1,6 @@
 package fm
 
+import grails.transaction.Transactional
 import org.springframework.web.multipart.MultipartFile
 
 import com.mongodb.DB
@@ -15,9 +16,9 @@ import org.apache.http.entity.mime.MultipartEntity
 import org.apache.http.entity.mime.HttpMultipartMode
 import org.apache.http.entity.mime.content.InputStreamBody
 
+@Transactional
 class UploadFilesService {
 
-    boolean transactional = true
     def config = Holders.config
     def filestoreDirectory = config.com.recomdata.FmFolderService.filestoreDirectory
     def fmFolderService

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/ClinicalDataResourceService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/ClinicalDataResourceService.groovy
@@ -40,8 +40,6 @@ import org.transmartproject.db.i2b2data.PatientDimension
 @Slf4j
 class ClinicalDataResourceService implements ClinicalDataResource {
 
-    static transactional = false
-
     def sessionFactory
 
     @Autowired

--- a/transmart-gwas-plugin/grails-app/services/com/recomdata/grails/plugin/gwas/GwasWebService.groovy
+++ b/transmart-gwas-plugin/grails-app/services/com/recomdata/grails/plugin/gwas/GwasWebService.groovy
@@ -21,14 +21,14 @@
 package com.recomdata.grails.plugin.gwas
 
 import au.com.bytecode.opencsv.CSVWriter
+import grails.transaction.Transactional
 import org.transmart.searchapp.SecureObject;
 import org.transmart.searchapp.AuthUserSecureAccess;
 import org.transmart.searchapp.AuthUser;
 import org.apache.commons.io.FileUtils;
 
+@Transactional
 class GwasWebService {
-
-    boolean transactional = true
 
     def dataSource
 

--- a/transmart-gwas-plugin/grails-app/services/com/recomdata/grails/plugin/gwas/RegionSearchService.groovy
+++ b/transmart-gwas-plugin/grails-app/services/com/recomdata/grails/plugin/gwas/RegionSearchService.groovy
@@ -20,11 +20,12 @@
 
 package com.recomdata.grails.plugin.gwas
 
+
 import de.DeSNPInfo;
+import grails.transaction.Transactional
 
+@Transactional
 class RegionSearchService {
-
-    boolean transactional = true
 
     def dataSource
     def grailsApplication

--- a/transmart-metacore-plugin/grails-app/services/com/thomsonreuters/lsps/transmart/HttpBuilderService.groovy
+++ b/transmart-metacore-plugin/grails-app/services/com/thomsonreuters/lsps/transmart/HttpBuilderService.groovy
@@ -4,9 +4,10 @@ import groovyx.net.http.*
 import static groovyx.net.http.ContentType.*
 import static groovyx.net.http.Method.*
 import org.apache.http.auth.*
+import grails.transaction.Transactional
 
+@Transactional
 class HttpBuilderService {
-	boolean transactional = true
 	
 	def getInstance(uri) {
 		def site = new HTTPBuilder(uri)

--- a/transmart-metacore-plugin/grails-app/services/com/thomsonreuters/lsps/transmart/MetacoreEnrichmentService.groovy
+++ b/transmart-metacore-plugin/grails-app/services/com/thomsonreuters/lsps/transmart/MetacoreEnrichmentService.groovy
@@ -4,10 +4,10 @@ import groovyx.net.http.ContentType
 import groovyx.net.http.HTTPBuilder
 import static groovyx.net.http.ContentType.*
 import static groovyx.net.http.Method.*
+import grails.transaction.Transactional
 
+@Transactional
 class MetacoreEnrichmentService {
-
-    boolean transactional = true
 
 	def springSecurityService
 	def grailsApplication

--- a/transmart-rest-api/grails-app/services/org/transmartproject/rest/StudyLoadingService.groovy
+++ b/transmart-rest-api/grails-app/services/org/transmartproject/rest/StudyLoadingService.groovy
@@ -38,8 +38,6 @@ import org.transmartproject.rest.ontology.OntologyTermCategory
 
 class StudyLoadingService {
 
-    static transactional = false
-
     static scope = 'request'
 
     public static final String STUDY_ID_PARAM = 'studyId'

--- a/transmartApp/grails-app/conf/application.groovy
+++ b/transmartApp/grails-app/conf/application.groovy
@@ -168,8 +168,6 @@ com.recomdata.skipdisclaimer = true
 
 grails.spring.bean.packages = []
 
-grails.spring.transactionManagement.proxies = true
-
 org.transmart.security.spnegoEnabled = false
 org.transmart.security.sniValidation = true
 org.transmart.security.sslValidation = true

--- a/transmartApp/grails-app/services/bio/BioDataService.groovy
+++ b/transmartApp/grails-app/services/bio/BioDataService.groovy
@@ -1,10 +1,10 @@
 package bio
 
+import grails.transaction.Transactional
 import org.transmart.biomart.BioData
 
+@Transactional
 class BioDataService {
-
-    boolean transactional = true
 
     def getBioDataObject(String uid) {
         def bioDataObject

--- a/transmartApp/grails-app/services/com/recomdata/asynchronous/JobStatusService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/asynchronous/JobStatusService.groovy
@@ -1,12 +1,12 @@
 package com.recomdata.asynchronous
 
 import com.recomdata.transmart.domain.i2b2.AsyncJob
+import grails.transaction.Transactional
 import groovy.time.TimeCategory
 import groovy.time.TimeDuration
 
+@Transactional
 class JobStatusService {
-
-    boolean transactional = true
 
     def jobResultsService
 

--- a/transmartApp/grails-app/services/com/recomdata/transmart/ExternaltoolService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/ExternaltoolService.groovy
@@ -1,8 +1,9 @@
 package com.recomdata.transmart
 
-class ExternaltoolService {
+import grails.transaction.Transactional
 
-    boolean transactional = true
+@Transactional
+class ExternaltoolService {
 
     def serviceMethod() {
 

--- a/transmartApp/grails-app/services/com/recomdata/transmart/asynchronous/job/AsyncJobService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/asynchronous/job/AsyncJobService.groovy
@@ -11,9 +11,8 @@ import org.quartz.Scheduler
 import org.springframework.transaction.annotation.Propagation
 import org.transmartproject.core.users.User
 
+@Transactional
 class AsyncJobService {
-
-    boolean transactional = true
 
     Scheduler quartzScheduler
     def springSecurityService

--- a/transmartApp/grails-app/services/com/recomdata/transmart/data/export/AdditionalDataService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/data/export/AdditionalDataService.groovy
@@ -1,12 +1,12 @@
 package com.recomdata.transmart.data.export
 
 import com.recomdata.transmart.data.export.util.FileWriterUtil
+import grails.transaction.Transactional
 
 import static org.transmart.authorization.QueriesResourceAuthorizationDecorator.checkQueryResultAccess;
 
+@Transactional
 class AdditionalDataService {
-
-    boolean transactional = true
 
     def i2b2HelperService
 

--- a/transmartApp/grails-app/services/com/recomdata/transmart/data/export/DataCountService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/data/export/DataCountService.groovy
@@ -15,8 +15,6 @@ class DataCountService {
 
     def dataSource
 
-    static transactional = false
-
     @Autowired
     QueriesResource queriesResource
 

--- a/transmartApp/grails-app/services/com/recomdata/transmart/data/export/ExportMetadataService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/data/export/ExportMetadataService.groovy
@@ -8,8 +8,6 @@ import org.transmartproject.export.HighDimExporter
 //TODO Remove duplicated code for both subset. Make code more generic for any number of subsets
 class ExportMetadataService {
 
-    static transactional = false
-
     def dataCountService
     def highDimensionResourceService
     def highDimExporterRegistry

--- a/transmartApp/grails-app/services/com/recomdata/transmart/data/export/GeneExpressionDataService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/data/export/GeneExpressionDataService.groovy
@@ -1,6 +1,7 @@
 package com.recomdata.transmart.data.export
 
 import com.recomdata.transmart.data.export.util.FileWriterUtil
+import grails.transaction.Transactional
 import grails.util.Holders
 import org.apache.commons.lang.StringUtils
 import org.rosuda.REngine.REXP
@@ -11,11 +12,11 @@ import java.sql.ResultSetMetaData
 
 import static org.transmart.authorization.QueriesResourceAuthorizationDecorator.checkQueryResultAccess
 
+@Transactional
 class GeneExpressionDataService {
 
     private String valueDelimiter = "\t";
     private int flushInterval = 5000;
-    boolean transactional = true
 
     def dataSource
     def i2b2HelperService

--- a/transmartApp/grails-app/services/com/recomdata/transmart/data/export/I2b2ExportHelperService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/data/export/I2b2ExportHelperService.groovy
@@ -4,7 +4,6 @@ import static org.transmart.authorization.QueriesResourceAuthorizationDecorator.
 
 class I2b2ExportHelperService {
 
-    static transactional = false
     def dataSource;
 
 

--- a/transmartApp/grails-app/services/com/recomdata/transmart/data/export/MetadataService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/data/export/MetadataService.groovy
@@ -1,6 +1,7 @@
 package com.recomdata.transmart.data.export
 
 import com.recomdata.transmart.data.export.util.FileWriterUtil
+import grails.transaction.Transactional
 import org.transmart.biomart.ClinicalTrial
 import org.transmart.biomart.Compound
 import org.transmart.biomart.Experiment
@@ -8,9 +9,8 @@ import org.transmart.biomart.Taxonomy
 
 import static org.transmart.authorization.QueriesResourceAuthorizationDecorator.checkQueryResultAccess
 
+@Transactional
 class MetadataService {
-
-    boolean transactional = true
 
     def dataSource
     def springSecurityService

--- a/transmartApp/grails-app/services/com/recomdata/transmart/data/export/SnpDataService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/data/export/SnpDataService.groovy
@@ -16,8 +16,6 @@ import static org.transmart.authorization.QueriesResourceAuthorizationDecorator.
 
 class SnpDataService {
 
-    boolean transactional = false
-
     def dataSource
     def i2b2HelperService
     def springSecurityService

--- a/transmartApp/grails-app/services/com/recomdata/transmart/data/export/SnpRefDataService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/data/export/SnpRefDataService.groovy
@@ -4,8 +4,6 @@ import de.DeSNPInfo;
 
 class SnpRefDataService {
 
-    boolean transactional = false
-
     def Collection<String> findRsIdByGeneNames(Collection geneNames) {
         return DeSNPInfo.executeQuery("SELECT distinct rsId FROM DeSNPInfo s WHERE s.geneName IN (:gn)", [gn: geneNames]);
 

--- a/transmartApp/grails-app/services/com/recomdata/transmart/data/export/SweepingService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/data/export/SweepingService.groovy
@@ -1,10 +1,10 @@
 package com.recomdata.transmart.data.export
 
 import com.recomdata.transmart.domain.i2b2.AsyncJob
+import grails.transaction.Transactional
 
+@Transactional
 class SweepingService {
-
-    boolean transactional = true
 
     def grailsApplication
 

--- a/transmartApp/grails-app/services/com/recomdata/transmart/data/export/VcfDataService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/data/export/VcfDataService.groovy
@@ -6,7 +6,6 @@ import de.DeVariantSubjectDetail
 import static org.transmart.authorization.QueriesResourceAuthorizationDecorator.checkQueryResultAccess;
 
 class VcfDataService {
-    boolean transactional = false
 
     def snpRefDataService
     def dataSource

--- a/transmartApp/grails-app/services/com/recomdata/transmart/plugin/PluginService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/plugin/PluginService.groovy
@@ -10,8 +10,6 @@ class PluginService {
 
     def grailsApplication
 
-    boolean transactional = false
-
     /**
      * Deprecated, will be removed once the registerPlugin and registerPluginModule methods are in-place
      *

--- a/transmartApp/grails-app/services/com/recomdata/transmart/util/FileDownloadService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/util/FileDownloadService.groovy
@@ -1,5 +1,6 @@
 package com.recomdata.transmart.util
 
+import grails.transaction.Transactional
 import org.apache.commons.lang.StringUtils
 
 import java.nio.channels.Channels
@@ -8,9 +9,8 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
+@Transactional
 class FileDownloadService {
-
-    boolean transactional = true
 
     def getFilename(String fileURIStr) {
         URI fileURI = new URI(fileURIStr);

--- a/transmartApp/grails-app/services/com/recomdata/transmart/util/UtilService.groovy
+++ b/transmartApp/grails-app/services/com/recomdata/transmart/util/UtilService.groovy
@@ -2,8 +2,6 @@ package com.recomdata.transmart.util
 
 class UtilService {
 
-    boolean transactional = false
-
     def toListString(List<Object> objList) {
         StringBuilder objToString = new StringBuilder()
         objList.each { obj ->

--- a/transmartApp/grails-app/services/org/transmart/SearchKeywordService.groovy
+++ b/transmartApp/grails-app/services/org/transmart/SearchKeywordService.groovy
@@ -1,5 +1,6 @@
 package org.transmart
 
+import grails.transaction.Transactional
 import org.transmart.biomart.BioAssayPlatform
 import org.transmart.biomart.BioDataExternalCode
 import org.transmart.biomart.ConceptCode
@@ -13,12 +14,10 @@ import org.transmart.searchapp.SearchKeywordTerm
  * $Revision: 9178 $
  *
  */
+@Transactional
 public class SearchKeywordService {
 
     def springSecurityService
-
-    // probably not needed but makes all methods transactional
-    static transactional = true
 
     //Hard-coded list of items that we consider filter categories... configure in Config/database?
     def filtercats = [

--- a/transmartApp/grails-app/services/org/transmartproject/app/GeneSignatureService.groovy
+++ b/transmartApp/grails-app/services/org/transmartproject/app/GeneSignatureService.groovy
@@ -21,6 +21,7 @@ package org.transmartproject.app
 
 import com.recomdata.genesignature.FileSchemaException
 import com.recomdata.search.query.Query
+import grails.transaction.Transactional
 import org.hibernate.type.LongType
 import org.springframework.web.multipart.MultipartFile
 import org.transmart.biomart.BioAssayDataAnnotation
@@ -39,15 +40,13 @@ import static org.transmartproject.db.support.DatabasePortabilityService.Databas
  * @author $Author: mmcduffie $
  * @version $Revision: 9178 $
  */
+@Transactional
 public class GeneSignatureService {
 
     // fold change metric codes
     static def METRIC_CODE_TRINARY = "TRINARY"
     static def METRIC_CODE_ACTUAL = "ACTUAL"
     static def METRIC_CODE_GENE_LIST = "NOT_USED"
-
-    // probably not needed but makes all methods transactional
-    static transactional = true
 
     // service injections
     def searchKeywordService

--- a/transmartApp/grails-app/services/org/transmartproject/app/I2b2HelperService.groovy
+++ b/transmartApp/grails-app/services/org/transmartproject/app/I2b2HelperService.groovy
@@ -49,7 +49,6 @@ class I2b2HelperService {
             "Sex", "Race", "Age", "Samples", "Trial"
     ]
 
-    boolean transactional = false;
     def sessionFactory
     def dataSource
     def conceptService

--- a/transmartApp/grails-app/services/org/transmartproject/app/JubilantResNetService.groovy
+++ b/transmartApp/grails-app/services/org/transmartproject/app/JubilantResNetService.groovy
@@ -15,7 +15,6 @@ import java.util.regex.Pattern
  * @version $Revision: 10098 $
  */
 class JubilantResNetService {
-    boolean transactional = false  // No need for this to be part of a transaction
 
     def searchFilter            // Passed from the JubilantController
     def misses = [] as Set        // Set that contains the proteins that could not be found

--- a/transmartApp/grails-app/services/org/transmartproject/app/SampleService.groovy
+++ b/transmartApp/grails-app/services/org/transmartproject/app/SampleService.groovy
@@ -1,13 +1,14 @@
 package org.transmartproject.app
 
+import grails.transaction.Transactional
+
+@Transactional
 class SampleService {
 
     def dataSource
     def i2b2HelperService
     def grailsApplication
     def solrService
-
-    boolean transactional = true
 
     //Populate the QT_PATIENT_SAMPLE_COLLECTION table based on a result_instance_id.
     public void generateSampleCollection(String result_instance_id) {

--- a/transmartApp/grails-app/services/org/transmartproject/app/SolrService.groovy
+++ b/transmartApp/grails-app/services/org/transmartproject/app/SolrService.groovy
@@ -1,12 +1,12 @@
 package org.transmartproject.app
 
+import grails.transaction.Transactional
 import groovyx.net.http.HTTPBuilder
 import org.jfree.util.Log
 
+@Transactional
 class SolrService {
     def grailsApplication
-
-    boolean transactional = true
 
     /**
      * This method will run a faceted search on the term provided and return a hashmap with hashmap[term]=facet_count

--- a/transmartApp/grails-app/services/transmartapp/OntologyService.groovy
+++ b/transmartApp/grails-app/services/transmartapp/OntologyService.groovy
@@ -1,11 +1,11 @@
 package transmartapp
 
 import grails.converters.JSON
+import grails.transaction.Transactional
 import org.transmart.searchapp.AuthUser
 
+@Transactional
 class OntologyService {
-
-    boolean transactional = true
 
     def i2b2HelperService
     def springSecurityService

--- a/transmartApp/grails-app/services/transmartapp/SolrFacetService.groovy
+++ b/transmartApp/grails-app/services/transmartapp/SolrFacetService.groovy
@@ -2,6 +2,7 @@ package transmartapp
 
 import fm.FmFolder
 import fm.FmFolderAssociation
+import grails.transaction.Transactional
 import grails.util.Holders
 import groovy.util.slurpersupport.NoChildren
 import groovy.util.slurpersupport.NodeChild
@@ -11,12 +12,12 @@ import org.transmart.biomart.BioMarker
 import org.transmart.biomart.BioMarkerExpAnalysisMV
 import org.transmartproject.db.support.InQuery
 
+@Transactional
 class SolrFacetService {
 
     def ontologyService
     def fmFolderService
 
-    boolean transactional = true
     def searchLog = [] //Search log for debug only! Will be shared across all sessions
 
     def getCombinedResults(categoryList, page, globalOperator, passedInSearchLog) {


### PR DESCRIPTION
In Grails 3.1 support for transactional proxies has been disabled by
default (in favor of the @Transactional transformation).
Changes:
- remove deprecated grails.spring.transactionManagement.proxies = true
- replace 'transactional = true' with @Transactional annotation
- remove 'transactional = false' from services - default setting for
Grails version 3.2 and above