### PR TITLE
Patientsetdescription

### DIFF
--- a/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/MultidimensionalDataResourceService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/MultidimensionalDataResourceService.groovy
@@ -554,7 +554,7 @@ class MultidimensionalDataResourceService implements MultiDimensionalDataResourc
 
         // 7. Update result instance and query instance
         resultInstance.setSize = resultInstance.realSetSize = patients.size()
-        resultInstance.description = "Patient set for \"${name}\""
+        resultInstance.description = name
         resultInstance.endDate = new Date()
         resultInstance.statusTypeId = QueryStatus.FINISHED.id
 

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/querytool/QueriesResourceService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/querytool/QueriesResourceService.groovy
@@ -146,7 +146,7 @@ class QueriesResourceService implements QueriesResource {
 
         // 7. Update result instance and query instance
         resultInstance.setSize = resultInstance.realSetSize = setSize
-        resultInstance.description = "Patient set for \"${definition.name}\""
+        resultInstance.description = definition.name
         resultInstance.endDate = new Date()
         resultInstance.statusTypeId = QueryStatus.FINISHED.id
 

--- a/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/PatientSetResourceTests.groovy
+++ b/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/PatientSetResourceTests.groovy
@@ -37,7 +37,7 @@ class PatientSetResourceTests extends ResourceSpec {
         that response.json, mapWith(
                 setSize: 1,
                 status: 'FINISHED',
-                description: 'Patient set for "My query"',
+                description: 'My query',
                 id: isA(Number),
                 username: 'user_-301',)
         that response.json, hasSelfLink("/${VERSION}/patient_sets/${response.json['id']}")

--- a/transmartApp/grails-app/controllers/org/transmartproject/app/SubsetController.groovy
+++ b/transmartApp/grails-app/controllers/org/transmartproject/app/SubsetController.groovy
@@ -90,7 +90,7 @@ class SubsetController {
         }
 
         def result = [success: success]
-        log.trace(result as JSON)
+        log.trace((result as JSON).toString())
         render result as JSON
     }
 


### PR DESCRIPTION
Implements GDB-71

Save only the user given resultInstanceId description

Instead of having a description of "Patient set for \"${name}\"", we just use `name` as description. The resultInstance.description does not appear to be used anywhere except in the rest api. TransmartApp uses the queryMaster.name property which contains the same name but without the "Patient set for" wrapping. This makes the query master name and the result instance description be identical.
