### PR TITLE
Allow escaping of + and _ with a backslash in column mapping file

### DIFF
--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/concept/ConceptFragment.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/concept/ConceptFragment.groovy
@@ -65,9 +65,19 @@ class ConceptFragment implements Comparable<ConceptFragment> {
         }
     }
     static ConceptFragment decode(String encodedConceptPath) {
+        // We need to double the escape chars in DELIMITER since it's interpreted again by replaceAll
+        String escapedDelimiter = DELIMITER.replace('\\','\\\\')
+
+        // Use negative lookbehind to allow + and _ to be escaped by preceding it with a backslash
         String conceptPath = encodedConceptPath
-                .replace('+', DELIMITER)
-                .replace('_', ' ')
+                // replace underscores not preceded by backslash with space
+                .replaceAll('(?<!\\\\)_',' ')
+                // replace +'es not preceded by backslash with the delimiter
+                .replaceAll('(?<!\\\\)\\+', escapedDelimiter)
+                // replace \+ with +
+                .replace('\\+','+')
+                // replace \_ with _
+                .replace('\\_','_')
 
         new ConceptFragment(conceptPath)
     }

--- a/transmart-batch/src/test/groovy/org/transmartproject/batch/concept/ConceptPathTests.groovy
+++ b/transmart-batch/src/test/groovy/org/transmartproject/batch/concept/ConceptPathTests.groovy
@@ -19,4 +19,52 @@ class ConceptPathTests {
                 hasProperty('parts', contains('A', 'B C')),
         )
     }
+
+    @Test
+    void testEscapePlus() {
+        ConceptFragment decodedConcept = ConceptFragment.decode('A+B\\+_C')
+
+        assertThat decodedConcept, allOf(
+                hasProperty('path', equalTo('A\\B+ C\\')),
+                hasProperty('parts', contains('A', 'B+ C'))
+        )
+
+        decodedConcept = ConceptFragment.decode('A+B+_C\\+')
+
+        assertThat decodedConcept, allOf(
+                hasProperty('path', equalTo('A\\B\\ C+\\')),
+                hasProperty('parts', contains('A', 'B', ' C+'))
+        )
+
+        decodedConcept = ConceptFragment.decode('\\+A+B+_C\\+')
+
+        assertThat decodedConcept, allOf(
+                hasProperty('path', equalTo('+A\\B\\ C+\\')),
+                hasProperty('parts', contains('+A', 'B', ' C+'))
+        )
+    }
+
+    @Test
+    void testEscapeUnderscore() {
+        ConceptFragment decodedConcept = ConceptFragment.decode('A+B\\_C')
+
+        assertThat decodedConcept, allOf(
+                hasProperty('path', equalTo('A\\B_C\\')),
+                hasProperty('parts', contains('A', 'B_C'))
+        )
+
+        decodedConcept = ConceptFragment.decode('A+B+_C\\_')
+
+        assertThat decodedConcept, allOf(
+                hasProperty('path', equalTo('A\\B\\ C_\\')),
+                hasProperty('parts', contains('A', 'B', ' C_'))
+        )
+
+        decodedConcept = ConceptFragment.decode('\\_A+B+_C')
+
+        assertThat decodedConcept, allOf(
+                hasProperty('path', equalTo('_A\\B\\ C\\')),
+                hasProperty('parts', contains('_A', 'B', ' C'))
+        )
+    }
 }


### PR DESCRIPTION
This change was already merged in [thehyve/transmart-batch](https://github.com/thehyve/transmart-batch). I propose to also have it here, as some concept names can require to have a `+` in the name.