### PR TITLE
Fix for null item values

### DIFF
--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/highdim/datastd/FilterNaNsItemProcessor.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/highdim/datastd/FilterNaNsItemProcessor.groovy
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component
 class FilterNaNsItemProcessor implements ItemProcessor<DataPoint, DataPoint> {
     @Override
     DataPoint process(DataPoint item) throws Exception {
-        if (!Double.isNaN(item.value)) {
+        if (item.value != null && !Double.isNaN(item.value)) {
             item
         } // else null (filter out)
     }


### PR DESCRIPTION
Double.isNaN() throws an exception when the input parameter is null