### PR TITLE
Fix generating tree node entries for non-categorical variables

### DIFF
--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/concept/ConceptTree.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/concept/ConceptTree.groovy
@@ -115,6 +115,12 @@ class ConceptTree {
         if (node) {
             return node
         }
+        if(ClinicalVariable.conceptTypeFor(variable) != ConceptType.CATEGORICAL) {
+            /* to generate missing parent tree nodes for non-categorical variables */
+            for (def p = variable.path.parent; p != null; p = p.parent) {
+                getOrGenerate(p, null, ConceptType.UNKNOWN)
+            }
+        }
         node = new ConceptNode(variable.path)
         node.type = ClinicalVariable.conceptTypeFor(variable)
         node.conceptName = variable.conceptName

--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/concept/ConceptTree.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/concept/ConceptTree.groovy
@@ -115,12 +115,12 @@ class ConceptTree {
         if (node) {
             return node
         }
-        if(ClinicalVariable.conceptTypeFor(variable) != ConceptType.CATEGORICAL) {
-            /* to generate missing parent tree nodes for non-categorical variables */
-            for (def p = variable.path.parent; p != null; p = p.parent) {
-                getOrGenerate(p, null, ConceptType.UNKNOWN)
-            }
+
+        /* to generate missing parent tree nodes for non-categorical variables */
+        if (variable.path.parent) {
+            getOrGenerate(variable.path.parent, null, ConceptType.UNKNOWN)
         }
+
         node = new ConceptNode(variable.path)
         node.type = ClinicalVariable.conceptTypeFor(variable)
         node.conceptName = variable.conceptName


### PR DESCRIPTION
Generating a missing parent node (a new row in the i2b2 table) was
possible only for categorical variables. Extended for other concept
types.

Fix for NOS-3: Numerical variables do not show up in the tree.