### PR TITLE
Fix Concept Path Templating for transmart-batch

### DIFF
--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/clinical/facts/ClinicalFactsRowSetFactory.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/clinical/facts/ClinicalFactsRowSetFactory.groovy
@@ -133,7 +133,8 @@ class ClinicalFactsRowSetFactory {
     private ConceptNode getOrGenerateConceptNode(ClinicalDataFileVariables variables,
                                                  ClinicalVariable var,
                                                  ClinicalDataRow row) {
-        if (!var.conceptPath) {
+
+        if (var.dataLabel == ClinicalVariable.TEMPLATE) {
             /*
              * Concepts are created and assigned types and ids
              */
@@ -141,6 +142,7 @@ class ClinicalFactsRowSetFactory {
             var.conceptPath = conceptPath
             var.path = conceptPath
         }
+
         ConceptNode concept = tree.conceptNodeForConceptPath(var.conceptPath)
         // if the concept doesn't yet exist (ie first record)
         concept = concept ?: tree.getOrGenerateConceptForVariable(var)
@@ -160,11 +162,6 @@ class ClinicalFactsRowSetFactory {
     private ConceptPath getOrGenerateConceptPath(ClinicalDataFileVariables variables,
                                                  ClinicalVariable var,
                                                  ClinicalDataRow row) {
-        if (var.conceptPath) {
-            return var.conceptPath
-        }
-
-        assert var.dataLabel == ClinicalVariable.TEMPLATE
 
         def relConceptPath = ConceptFragment.decode(var.categoryCode).path
 


### PR DESCRIPTION
transmart-batch failed to dynamically create concept paths (i.e. when DATALABEL is used as placeholder in the Category Code column of the column mapping).
Only first concept was created were and all the other values were mapped to the same concept.