### PR TITLE
Fix cache key generation for constraints.

### DIFF
--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/MultiDimConstraint.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/MultiDimConstraint.groovy
@@ -8,4 +8,5 @@ package org.transmartproject.core.multidimquery
  * No methods, the constraint objects are used internally
  */
 interface MultiDimConstraint {
+    String toJson()
 }

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/MultidimensionalDataResourceService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/MultidimensionalDataResourceService.groovy
@@ -382,7 +382,7 @@ class MultidimensionalDataResourceService implements MultiDimensionalDataResourc
 
     @Override
     @Cacheable(value = 'org.transmartproject.db.clinical.MultidimensionalDataResourceService.cachedCounts',
-            key = '{ #constraint.toString(), #user.username }')
+            key = '{ #constraint.toJson(), #user.username }')
     Counts cachedCounts(MultiDimConstraint constraint, User user) {
         counts(constraint, user)
     }
@@ -653,7 +653,7 @@ class MultidimensionalDataResourceService implements MultiDimensionalDataResourc
 
     @Override
     @Cacheable(value = 'org.transmartproject.db.clinical.MultidimensionalDataResourceService.cachedPatientCount',
-            key = '{ #constraint.toString(), #user.username }')
+            key = '{ #constraint.toJson(), #user.username }')
     Long cachedPatientCount(MultiDimConstraint constraint, User user) {
         getDimensionElementsCount(PATIENT, constraint, user)
     }

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/multidimquery/query/Constraint.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/multidimquery/query/Constraint.groovy
@@ -207,8 +207,7 @@ class Field implements Validateable {
  */
 abstract class Constraint implements Validateable, MultiDimConstraint {
 
-    @Override
-    String toString() {
+    String toJson() {
         (this as JSON).toString()
     }
 


### PR DESCRIPTION
Use custom method name instead of overriding toString() as subclasses tend to chenge it often in a way that does not hold uniqueness garantee.