### PR TITLE
Update dependency path to dataExportRScripts

### DIFF
--- a/transmart-server/build.gradle
+++ b/transmart-server/build.gradle
@@ -64,7 +64,7 @@ war {
             into 'Rscripts'
         })
         with copySpec({
-            from 'src/main/resources/dataExportRScripts'
+            from '../transmartApp/src/main/resources/dataExportRScripts'
             into 'dataExportRScripts'
         })
         with copySpec({


### PR DESCRIPTION
The current path `src/main/resources/dataExportRScripts` doesn't exist. The folder is however available in transmartApp. Should we update the path to transmartApp or move the scripts at the specified location?