### PR TITLE
Refactor cache rebuild

### DIFF
--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/MultiDimensionalDataResource.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/MultiDimensionalDataResource.groovy
@@ -48,7 +48,13 @@ interface MultiDimensionalDataResource {
      */
     Counts counts(MultiDimConstraint constraint, User user)
 
-    Counts cachedCounts(MultiDimConstraint constraint, User user)
+    /**
+     * Computes observations and patient counts for all data accessible by the user
+     * (applying the 'true' constraint) and puts the result in the counts cache.
+     *
+     * @param user the user to compute the counts for.
+     */
+    void rebuildCountsCacheForUser(User user)
 
     /**
      * Observation and patient counts per concept:
@@ -86,6 +92,12 @@ interface MultiDimensionalDataResource {
      */
     Map<String, Map<String, Counts>> countsPerStudyAndConcept(MultiDimConstraint constraint, User user)
 
+    /**
+     * Computes counts per study and concept for all data accessible for all users
+     * and puts the result in the counts cache.
+     */
+    void rebuildCountsPerStudyAndConceptCache()
+
     Iterable getDimensionElements(Dimension dimension, MultiDimConstraint constraint, User user)
 
     QueryResult createPatientSetQueryResult(String name, MultiDimConstraint constraint, User user, String constraintText, String apiVersion)
@@ -96,6 +108,17 @@ interface MultiDimensionalDataResource {
 
     Long getDimensionElementsCount(Dimension dimension, MultiDimConstraint constraint, User user)
 
+    /**
+     * Patient count: counts the number of patients that satisfy the constraint and that
+     * the user has access to.
+     *
+     * Deprecated in favour of {@link #counts(MultiDimConstraint, User)}.
+     *
+     * @param constraint the constraint.
+     * @param user the current user.
+     * @return the number of patients.
+     */
+    @Deprecated
     Long cachedPatientCount(MultiDimConstraint constraint, User user)
 
     /**

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/tree/TreeCacheService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/tree/TreeCacheService.groovy
@@ -3,6 +3,7 @@
 package org.transmartproject.db.tree
 
 import grails.plugin.cache.CacheEvict
+import grails.plugin.cache.CachePut
 import grails.plugin.cache.Cacheable
 import groovy.transform.CompileStatic
 import org.hibernate.SessionFactory
@@ -114,21 +115,7 @@ class TreeCacheService {
         forest[topLevel]
     }
 
-    /**
-     * Fetches a subtree for a user. Returns the list of to level tree nodes,
-     * with the child nodes embedded.
-     *
-     * @param isAdmin whether the user is admin or not.
-     * @param studyTokens Secure access tokens of the studies the user has access to.
-     * @param rootPath restricts to fetching only starting from the specified root element.
-     *        (default: null, meaning no restriction.)
-     * @param maxLevel restricts to fetching up to the specified level.
-     *        (default: 0, meaning no restriction.)
-     *
-     * @return the list of top level tree nodes with child nodes embedded.
-     */
-    @Cacheable('org.transmartproject.db.tree.TreeCacheService')
-    List<TreeNode> fetchCachedSubtree(boolean isAdmin = false, List<String> studyTokens = [], String rootPath = I2b2Secure.ROOT, int maxLevel = 0) {
+    List<TreeNode> fetchSubtree(boolean isAdmin = false, List<String> studyTokens = [], String rootPath = I2b2Secure.ROOT, int maxLevel = 0) {
         log.info "Fetching tree nodes ..."
         DetachedCriteria criteria = DetachedCriteria.forClass(I2b2Secure)
         if (!isAdmin) {
@@ -154,6 +141,31 @@ class TreeCacheService {
         log.debug "Forest growing took ${t3.time - t2.time} ms."
 
         forest
+    }
+
+    @CachePut(value = 'org.transmartproject.db.tree.TreeCacheService',
+            key = '{ #isAdmin, #studyTokens, #rootPath, #maxLevel }')
+    List<TreeNode> updateSubtreeCache(boolean isAdmin = false, List<String> studyTokens = [], String rootPath = I2b2Secure.ROOT, int maxLevel = 0) {
+        fetchSubtree(isAdmin, studyTokens, rootPath, maxLevel)
+    }
+
+    /**
+     * Fetches a subtree for a user. Returns the list of to level tree nodes,
+     * with the child nodes embedded.
+     *
+     * @param isAdmin whether the user is admin or not.
+     * @param studyTokens Secure access tokens of the studies the user has access to.
+     * @param rootPath restricts to fetching only starting from the specified root element.
+     *        (default: null, meaning no restriction.)
+     * @param maxLevel restricts to fetching up to the specified level.
+     *        (default: 0, meaning no restriction.)
+     *
+     * @return the list of top level tree nodes with child nodes embedded.
+     */
+    @Cacheable(value = 'org.transmartproject.db.tree.TreeCacheService',
+            key = '{ #isAdmin, #studyTokens, #rootPath, #maxLevel }')
+    List<TreeNode> fetchCachedSubtree(boolean isAdmin = false, List<String> studyTokens = [], String rootPath = I2b2Secure.ROOT, int maxLevel = 0) {
+        fetchSubtree(isAdmin, studyTokens, rootPath, maxLevel)
     }
 
     /**

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/tree/TreeService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/tree/TreeService.groovy
@@ -250,16 +250,14 @@ class TreeService implements TreeResource {
         if (!tryLock()) {
             throw new ServiceNotAvailableException('Rebuild operation already in progress.')
         }
+        log.info 'Clearing all caches ...'
+        clearCache(currentUser)
         log.debug "Starting task (lock: ${sharedLock.locked})"
         task {
             log.debug "Task started (lock: ${sharedLock.locked})"
             def session = sessionFactory.openSession()
             try {
                 def stopWatch = new StopWatch('Rebuild cache')
-                log.info 'Clearing all caches ...'
-                stopWatch.start('Clearing the caches')
-                clearCache(currentUser)
-                stopWatch.stop()
                 usersResource.getUsers().each {
                     DbUser user = (DbUser)it
                     log.info "Rebuilding the cache for user ${user.username} ..."

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/util/SharedLock.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/util/SharedLock.groovy
@@ -1,0 +1,75 @@
+package org.transmartproject.db.util
+
+import groovy.transform.CompileStatic
+
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * Lock that can be shared between threads and can be released
+ * by another thread than the thread that locked it.
+ * E.g., when a thread first acquires a lock, then spawns a new thread
+ * that should release the lock when it is completed.
+ *
+ * Example use:
+ * <code>
+ *     if (!lock.tryLock()) {
+ *          throw new RuntimeException('Resource is locked')
+ *     }
+ *     task {
+ *         try {
+ *             log.info 'Task started.'
+ *             // perform task in task thread
+ *         } finally {
+ *             lock.unlock()
+ *         }
+ *     }
+ * </code>
+ */
+@CompileStatic
+class SharedLock {
+
+    static class SimpleLock {
+        boolean locked
+    }
+
+    final private SimpleLock sharedLock = new SimpleLock(locked: false)
+    final private Lock lockLock = new ReentrantLock()
+
+    /**
+     * Checks if the lock is locked.
+     *
+     * @return true iff the lock is locked.
+     */
+    boolean isLocked() {
+        sharedLock.locked
+    }
+
+    /**
+     * Try to acquire the lock. Returns false if the lock is not available,
+     * true if the lock is successfully acquired.
+     *
+     * @return true iff the lock is successfully acquired.
+     */
+    boolean tryLock() {
+        lockLock.lock()
+        if (locked) {
+            lockLock.unlock()
+            return false
+        } else {
+            sharedLock.locked = true
+            lockLock.unlock()
+            return true
+        }
+    }
+
+    /**
+     * Release the lock.
+     */
+    void unlock() {
+        lockLock.lock()
+        sharedLock.locked = false
+        lockLock.unlock()
+    }
+
+}

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/QueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/QueryController.groovy
@@ -153,7 +153,7 @@ class QueryController extends AbstractQueryController {
             return
         }
         User user = (User) usersResource.getUserFromUsername(currentUser.username)
-        def counts = multiDimService.cachedCounts(constraint, user)
+        def counts = multiDimService.counts(constraint, user)
         render counts as JSON
     }
 


### PR DESCRIPTION
- Move shared lock to separate class;
- Fix issues with missing session in task thread;
- Fix tree nodes cache key;
- Change precompute logic to reuse counts per concept across users;
- Also precompute observation and patient counts.