### PR TITLE
Pack flag for /v2/observations

### DIFF
--- a/open-api/swagger.yaml
+++ b/open-api/swagger.yaml
@@ -745,6 +745,14 @@ paths:
           description: 'The projection. Only used with high dimensional data Example: `all_data`, `zscore`,
           `log_intensity`. Default: `all_data`.'
           type: string
+        - name: pack
+          required: false
+          in: query
+          description: |
+            Required for protobuf output. This parameter indicates if the protobuf is packed into a
+            smaller format. Values: 't', 'f'. Packing is not yet fully implemented so currently the value must be 'f'.
+            This parameter may become optional for protobuf output in the future.
+          type: string
       responses:
         200:
           description: |

--- a/transmart-rest-api/build.gradle
+++ b/transmart-rest-api/build.gradle
@@ -50,4 +50,5 @@ bootRun {
 // Uncomment to show standard out/error output
 //test.testLogging.showStandardStreams = true
 
-
+// Force selected tests to always run, even if Gradle thinks they are up to date
+test.outputs.upToDateWhen {false}

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/QueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/QueryController.groovy
@@ -62,9 +62,13 @@ class QueryController extends AbstractQueryController {
      */
     def observations() {
         def args = getGetOrPostParams()
-        checkForUnsupportedParams(args, ['type', 'constraint', 'assay_constraint', 'biomarker_constraint', 'projection'])
+        checkForUnsupportedParams(args, ['type', 'constraint', 'assay_constraint', 'biomarker_constraint',
+                                         'projection', 'pack'])
 
         if (args.type == null) throw new InvalidArgumentsException("Parameter 'type' is required")
+
+        if (args.pack != 'f' && contentFormat == Format.PROTOBUF) throw new InvalidArgumentsException(
+                "Parameter 'pack' is required for protobuf output, currently only the value 'f' is supported.")
 
         if (args.type == 'clinical') {
             clinicalObservations(args.constraint)

--- a/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/QueryControllerSpec.groovy
+++ b/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/QueryControllerSpec.groovy
@@ -106,4 +106,32 @@ class QueryControllerSpec extends MarshallerSpec {
         result instanceof List
     }
 
+    void 'test pack parameter'() {
+        when:
+        def constraintTxt = URLEncoder.encode(([
+                type: 'negation',
+                arg: [
+                        type: 'true'
+                ]
+        ] as JSON).toString(), 'UTF-8')
+        def response = getProtobuf("$baseURL/$VERSION/observations?type=clinical&constraint=$constraintTxt")
+
+        then:
+        response.statusCode.value() == 400
+        new JsonSlurper().parse(response.body.byteArray).message ==
+                "Parameter 'pack' is required for protobuf output, currently only the value 'f' is supported."
+
+        when:
+        // Only as long as packing is not implemented
+        response = getProtobuf("$baseURL/$VERSION/observations?type=clinical&pack=t&constraint=$constraintTxt")
+        then:
+        response.statusCode.value() == 400
+        new JsonSlurper().parse(response.body.byteArray).message ==
+                "Parameter 'pack' is required for protobuf output, currently only the value 'f' is supported."
+
+        when:
+        response = getProtobuf("$baseURL/$VERSION/observations?type=clinical&pack=f&constraint=$constraintTxt")
+        then:
+        response.statusCode.value() == 200
+    }
 }

--- a/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/marshallers/MarshallerSpec.groovy
+++ b/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/marshallers/MarshallerSpec.groovy
@@ -17,6 +17,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestTemplate
+import org.transmartproject.rest.MultidimensionalDataService
 import spock.lang.Specification
 
 @FreshRuntime
@@ -71,4 +72,13 @@ class MarshallerSpec extends Specification {
         response
     }
 
+    ResponseEntity<Resource> getProtobuf(url) {
+        HttpHeaders headers = new HttpHeaders()
+        headers.set(HttpHeaders.ACCEPT, MultidimensionalDataService.Format.PROTOBUF as String)
+        HttpEntity requestEntity = new HttpEntity(headers)
+        ResponseEntity<Resource> response = restTemplate.exchange(
+                url, HttpMethod.GET, requestEntity,
+                new ParameterizedTypeReference<Resource>() {});
+        response
+    }
 }


### PR DESCRIPTION
Require the 'pack' flag for Protobuf output. Accepted values: 't' and 'f', but currently only 'f' is supported.

This flag ensures we can add the packed protobuf output format without breaking compatibility in the future.
If we decide to use packed or unpacked as the default, we can make this flag optional in the future.