### PR TITLE
Fix issues related to running on Windows

### DIFF
--- a/transmart-server/build.gradle
+++ b/transmart-server/build.gradle
@@ -40,14 +40,45 @@ assets {
     packagePlugin = true
 }
 
-bootRun {
-    jvmArgs = ['-Xmx4096m']
+if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
+    task pathingJarTmServer(type: Jar) {
+        dependsOn configurations.runtime
+        appendix = 'pathing'
 
-    // In development mode, set the TRANSMART_DEBUG_PORT environment variable to a port number to enable debugging on that port
-    if(! (System.env.TRANSMART_DEBUG_PORT ?: '').empty) {
-        def port = System.env.TRANSMART_DEBUG_PORT
-        assert port.isInteger() && (port as int) in 0..<2**16, "TRANSMART_DEBUG_PORT environment variable is not a valid port number: '$port'"
-        jvmArgs += ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$port"]
+        doFirst {
+            manifest {
+                attributes 'Class-Path': configurations.runtime.files.collect {
+                    it.toURL().toString().replaceFirst(/file:\/+/, '/').replaceAll(' ', '%20')
+                }.join(' ')
+            }
+        }
+    }
+
+    bootRun {
+        dependsOn pathingJarTmServer
+        doFirst {
+            classpath = files("$buildDir/classes/main", "$buildDir/resources/main", pathingJarTmServer.archivePath)
+        }
+
+        jvmArgs = ['-Xmx4096m']
+
+        // In development mode, set the TRANSMART_DEBUG_PORT environment variable to a port number to enable debugging on that port
+        if(! (System.env.TRANSMART_DEBUG_PORT ?: '').empty) {
+            def port = System.env.TRANSMART_DEBUG_PORT
+            assert port.isInteger() && (port as int) in 0..<2**16, "TRANSMART_DEBUG_PORT environment variable is not a valid port number: '$port'"
+            jvmArgs += ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$port"]
+        }
+    }
+} else {
+    bootRun {
+        jvmArgs = ['-Xmx4096m']
+
+        // In development mode, set the TRANSMART_DEBUG_PORT environment variable to a port number to enable debugging on that port
+        if(! (System.env.TRANSMART_DEBUG_PORT ?: '').empty) {
+            def port = System.env.TRANSMART_DEBUG_PORT
+            assert port.isInteger() && (port as int) in 0..<2**16, "TRANSMART_DEBUG_PORT environment variable is not a valid port number: '$port'"
+            jvmArgs += ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$port"]
+        }
     }
 }
 

--- a/transmart-server/grails-app/init/org/transmart/server/Application.groovy
+++ b/transmart-server/grails-app/init/org/transmart/server/Application.groovy
@@ -24,7 +24,7 @@ class Application extends GrailsAutoConfiguration implements EnvironmentAware {
         }
 
         String applicationName = 'transmart'
-        String userHome = System.getProperty('user.home')
+        String userHome = System.getProperty('user.home').replace('\\','/')
 
         addToEnvironmentAsFirstSource(environment, "${userHome}/.grails/${applicationName}Config/Config.groovy")
         addToEnvironmentAsFirstSource(environment, "${userHome}/.grails/${applicationName}Config/DataSource.groovy")


### PR DESCRIPTION
- Add a `pathingJar` for transmart-server to deal with long classpaths
- Replace backslashes in `user.home` system property with forward slashes so it can be used as part of a URI