### PR TITLE
Counts per study per concept master

### DIFF
--- a/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/MultidimensionalDataResourceService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/MultidimensionalDataResourceService.groovy
@@ -11,6 +11,7 @@ import grails.plugin.cache.Cacheable
 import grails.transaction.Transactional
 import grails.util.Holders
 import groovy.transform.CompileStatic
+import groovy.transform.Immutable
 import groovy.transform.TupleConstructor
 import org.apache.commons.lang.NotImplementedException
 import org.hibernate.Criteria
@@ -465,23 +466,56 @@ class MultidimensionalDataResourceService implements MultiDimensionalDataResourc
         } as Map<String, Counts>
     }
 
-    @Override
-    Map<String, Map<String, Counts>> countsPerStudyAndConcept(MultiDimConstraint constraint, User user) {
-        assert constraint instanceof Constraint
-        log.debug "Computing counts per study and concept ..."
+    @Immutable
+    class ConceptStudyCountRow {
+        String conceptCode
+        String studyId
+        Counts summary
+    }
+
+    @Transactional(readOnly = true)
+    Map<String, Map<String, Counts>> freshCountsPerStudyAndConcept(MultiDimConstraint constraint, User user) {
+        log.debug "Computing counts per study and concept..."
         def t1 = new Date()
         checkAccess(constraint, user)
-        MultiDimensionalDataResource wrappedThis =
-                Holders.grailsApplication.mainContext.multidimensionalDataResourceService
-        def studies = accessControlChecks.getDimensionStudiesForUser((DbUser) user)
-        Map<String, Map<String, Counts>> result = studies.collectEntries { Study study ->
-            Constraint studySpecificConstraint =
-                    new AndConstraint(args: [constraint, new StudyNameConstraint(studyId: study.studyId)])
-            [study.studyId, wrappedThis.countsPerConcept(studySpecificConstraint, user)]
-        }
+        QueryBuilder builder = getCheckedQueryBuilder(user)
+        DetachedCriteria criteria = builder.buildCriteria((Constraint) constraint)
+                .setProjection(Projections.projectionList()
+                .add(Projections.groupProperty('conceptCode'), 'conceptCode')
+                .add(Projections.groupProperty("${builder.getAlias('trialVisit')}.study"), 'study')
+                .add(Projections.rowCount(), 'observationCount')
+                .add(Projections.countDistinct('patient'), 'patientCount'))
+                .setResultTransformer(Transformers.ALIAS_TO_ENTITY_MAP)
+        List result = getList(criteria)
         def t2 = new Date()
         log.debug "Computed counts (took ${t2.time - t1.time} ms.)"
-        return result
+        List<ConceptStudyCountRow> counts = result.collect{ Map row ->
+            new ConceptStudyCountRow(conceptCode: row.conceptCode as String, studyId: (row.study as Study).studyId,
+                    summary: new Counts(observationCount: row.observationCount as Long, patientCount: row.patientCount as Long))
+        }
+        counts.groupBy { it.studyId }.collectEntries { String studyId, List<ConceptStudyCountRow> rowsPerStudy ->
+            [(studyId): rowsPerStudy.groupBy { it.conceptCode}.collectEntries { String conceptCode, List<ConceptStudyCountRow> rows ->
+                [(conceptCode): rows[0].summary]
+            } as Map<String, Counts>
+            ]
+        } as Map<String, Map<String, Counts>>
+    }
+
+    @Override
+    @Cacheable(value = 'org.transmartproject.db.clinical.MultidimensionalDataResourceService.countsPerStudyAndConcept',
+            key = '{ #constraint.toJson(), #user.username }')
+    @Transactional(readOnly = true)
+    Map<String, Counts> countsPerStudyAndConcept(MultiDimConstraint constraint, User user) {
+        log.debug "Fetching counts per per study per concept for user: ${user.username}, constraint: ${constraint.toJson()}"
+        freshCountsPerStudyAndConcept(constraint, user)
+    }
+
+    @CachePut(value = 'org.transmartproject.db.clinical.MultidimensionalDataResourceService.countsPerStudyAndConcept',
+            key = '{ #constraint.toJson(), #user.username }')
+    @Transactional(readOnly = true)
+    Map<String, Counts> updateCountsPerStudyAndConcept(MultiDimConstraint constraint, User user, Map<String, Counts> newCounts) {
+        log.debug "Updating counts per study per concept cache for user: ${user.username}, constraint: ${constraint.toJson()}"
+        newCounts
     }
 
     @Override
@@ -490,37 +524,28 @@ class MultidimensionalDataResourceService implements MultiDimensionalDataResourc
         log.info "Rebuilding counts per study and concept cache ..."
         def t1 = new Date()
 
-        DetachedCriteria criteria = DetachedCriteria.forClass(ObservationFact, 'observation_fact')
-                .createAlias('trialVisit', 'trial_visit')
-                .setProjection(Projections.projectionList()
-                    .add(Projections.groupProperty('trial_visit.study'), 'study')
-                    .add(Projections.groupProperty('conceptCode'), 'conceptCode')
-                    .add(Projections.rowCount(), 'observationCount')
-                    .add(Projections.countDistinct('patient'), 'patientCount'))
-                .setResultTransformer(Transformers.ALIAS_TO_ENTITY_MAP)
-        List rows = getList(criteria)
-        def rowsPerStudy = rows.groupBy { Map row -> ((row.study as Study).studyId) }
-        def countsPerStudy = rowsPerStudy.collectEntries { studyId, studyRows ->
-            [(studyId): studyRows.collectEntries { Map row ->
-                [(row.conceptCode):
-                         new Counts(observationCount: row.observationCount as Long, patientCount: row.patientCount as Long)]
-            } as Map<String, Counts>]
-        } as Map<String, Map>
-
-        def t2 = new Date()
-        log.info "Computed counts (took ${t2.time - t1.time} ms.)"
+        Map<String, Map<String, Counts>> countsPerStudyAndConcept = [:]
 
         MultidimensionalDataResourceService wrappedThis =
                 Holders.grailsApplication.mainContext.multidimensionalDataResourceService
-
+        //Sharing counts between users does not always work for other type of constraints
+        // e.g. In case when cross-study concepts involved and different users have different rights on them.
+        MultiDimConstraint constraintToPreCache = new TrueConstraint()
         usersResource.getUsers().each { User user ->
             log.info "Rebuilding counts per study and concept cache for user ${user.username} ..."
-            def studies = accessControlChecks.getDimensionStudiesForUser((DbUser) user)
-            for (Study study : studies) {
-                def constraint = new AndConstraint(args: [new TrueConstraint(), new StudyNameConstraint(studyId: study.studyId)])
-                wrappedThis.updateCountsPerConceptCache(constraint, user, countsPerStudy[study.studyId])
+            Collection<Study> studies = accessControlChecks.getDimensionStudiesForUser((DbUser) user)
+            def studyIds = studies*.studyId as Set
+            def notFetchedStudyIds = studyIds - countsPerStudyAndConcept.keySet()
+            if (notFetchedStudyIds) {
+                Map<String, Map<String, Counts>> freshCounts = freshCountsPerStudyAndConcept(constraintToPreCache, user)
+                countsPerStudyAndConcept.putAll(freshCountsPerStudyAndConcept(constraintToPreCache, user))
             }
+            def countsForUser = studyIds.collectEntries { String studyId -> [studyId, countsPerStudyAndConcept[studyId]] }
+            wrappedThis.updateCountsPerStudyAndConcept(constraintToPreCache, user, countsForUser)
         }
+
+        def t2 = new Date()
+        log.info "Caching counts per study and concept took ${t2.time - t1.time} ms."
     }
 
     /**


### PR DESCRIPTION
Return back one query to get counts per study and concept. Introduce cache for the counts.