### PR TITLE
Fix serialisation of constraints on tree nodes; added tests.

### DIFF
--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -1398,7 +1398,7 @@
             "name": "constraints",
             "in": "query",
             "type": "boolean",
-            "description": "Flag if the constraints should be included in the result (always true for hal, defaults to true for json)"
+            "description": "Flag if the constraints should be included in the result (always false for hal, defaults to true for json)"
           },
           {
             "name": "counts",
@@ -2691,23 +2691,23 @@
           }
         },
         "observationCount": {
-          "description": "only available on ConceptNodes",
+          "description": "only available on concept nodes",
           "type": "integer"
         },
         "patientCount": {
-          "description": "only available on ConceptNodes",
+          "description": "only available on concept nodes",
           "type": "integer"
         },
         "constraint": {
-          "description": "only available on ConceptNodes",
+          "description": "only available on concept nodes; not available for HAL.",
           "type": "object",
           "properties": {
             "type": {
-              "description": "Example: ConceptConstraint",
+              "description": "Example: `concept`",
               "type": "string"
             },
-            "path": {
-              "description": "Example: `\\Public Studies\\CLINICAL_TRIAL\\Demography\\Age\\`",
+            "conceptCode": {
+              "description": "Example: `age`",
               "type": "string"
             }
           }

--- a/open-api/swagger.yaml
+++ b/open-api/swagger.yaml
@@ -1268,7 +1268,7 @@ paths:
         - name: constraints
           in: query
           type: boolean
-          description: 'Flag if the constraints should be included in the result (always true for hal, defaults to true for json)'
+          description: 'Flag if the constraints should be included in the result (always false for hal, defaults to true for json)'
         - name: counts
           in: query
           type: boolean
@@ -2165,20 +2165,20 @@ definitions:
           description: 'Example: [FOLDER, ACTIVE, STUDY]'
           type: string
       observationCount:
-        description: 'only available on ConceptNodes'
+        description: 'only available on concept nodes'
         type: integer
       patientCount:
-        description: 'only available on ConceptNodes'
+        description: 'only available on concept nodes'
         type: integer
       constraint:
-        description: 'only available on ConceptNodes'
+        description: 'only available on concept nodes; not available for HAL.'
         type: object
         properties:
           type:
-            description: 'Example: ConceptConstraint'
+            description: 'Example: `concept`'
             type: string
-          path:
-            description: 'Example: `\Public Studies\CLINICAL_TRIAL\Demography\Age\`'
+          conceptCode:
+            description: 'Example: `age`'
             type: string
   
   v2Study:

--- a/open-api/swagger_spec.js
+++ b/open-api/swagger_spec.js
@@ -1398,7 +1398,7 @@ var spec = {
             "name": "constraints",
             "in": "query",
             "type": "boolean",
-            "description": "Flag if the constraints should be included in the result (always true for hal, defaults to true for json)"
+            "description": "Flag if the constraints should be included in the result (always false for hal, defaults to true for json)"
           },
           {
             "name": "counts",
@@ -2691,23 +2691,23 @@ var spec = {
           }
         },
         "observationCount": {
-          "description": "only available on ConceptNodes",
+          "description": "only available on concept nodes",
           "type": "integer"
         },
         "patientCount": {
-          "description": "only available on ConceptNodes",
+          "description": "only available on concept nodes",
           "type": "integer"
         },
         "constraint": {
-          "description": "only available on ConceptNodes",
+          "description": "only available on concept nodes; not available for HAL.",
           "type": "object",
           "properties": {
             "type": {
-              "description": "Example: ConceptConstraint",
+              "description": "Example: `concept`",
               "type": "string"
             },
-            "path": {
-              "description": "Example: `\\Public Studies\\CLINICAL_TRIAL\\Demography\\Age\\`",
+            "conceptCode": {
+              "description": "Example: `age`",
               "type": "string"
             }
           }

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/multidimquery/query/CombinationConstraintRewriter.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/multidimquery/query/CombinationConstraintRewriter.groovy
@@ -19,7 +19,7 @@ class CombinationConstraintRewriter extends NormaliseConstraintRewriter {
             return constraint
         }
         def combination = (Combination)constraint
-        if (combination.operator != Operator.OR) {
+        if (combination.getOperator() != Operator.OR) {
             return combination
         }
 
@@ -66,7 +66,7 @@ class CombinationConstraintRewriter extends NormaliseConstraintRewriter {
             return this.build((Constraint)normalisedConstraint)
         }
         def combination = (Combination)normalisedConstraint
-        if (combination.operator != Operator.OR) {
+        if (combination.getOperator() != Operator.OR) {
             return new Combination(combination.operator,
                     combination.args.collect { build(it) }
             )
@@ -74,7 +74,7 @@ class CombinationConstraintRewriter extends NormaliseConstraintRewriter {
         def disjuncts = combination.args
         // Filter on disjuncts of the form (StudyNameConstraint and ...)
         def groups = disjuncts.split {
-            if (it instanceof Combination && ((Combination)it).operator == Operator.AND) {
+            if (it instanceof Combination && ((Combination)it).getOperator() == Operator.AND) {
                 def conjunct = (Combination) it
                 return conjunct.args.findAll { it instanceof StudyNameConstraint }.size() == 1
             }

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/multidimquery/query/ConstraintSerialiser.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/multidimquery/query/ConstraintSerialiser.groovy
@@ -102,16 +102,16 @@ class ConstraintSerialiser extends ConstraintBuilder<Void> {
     @Override
     Void build(Combination constraint) {
         writer.name('type')
-        switch(constraint.operator) {
+        switch(constraint.getOperator()) {
             case Operator.AND:
-                writer.value(AndConstraint.constraintName)
+                writer.value('and')
                 break
             case Operator.OR:
-                writer.value(OrConstraint.constraintName)
+                writer.value('or')
                 break
             default:
                 writer.value(Combination.constraintName)
-                writer.name('operator').value(constraint.operator.symbol)
+                writer.name('operator').value(constraint.getOperator().symbol)
         }
         writer.name('args')
         buildArray(constraint.args)

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/tree/TreeNodeConstraintHelper.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/tree/TreeNodeConstraintHelper.groovy
@@ -32,9 +32,9 @@ class TreeNodeConstraintHelper {
         }
         switch (node.tableName) {
             case 'concept_dimension':
-                if (node.columnName in ['concept_path', 'concept_code'] && node.hasOperator(['=', 'like'])) {
+                if (node.columnName in ['concept_path', 'concept_cd'] && node.hasOperator(['=', 'like'])) {
                     // constraint for the concept
-                    def conceptConstraint = new ConceptConstraint(conceptCode: node.conceptCode)
+                    def conceptConstraint = new ConceptConstraint(node.conceptCode)
                     // lookup study for this node
                     def parentStudyId = node.study?.studyId
                     if (!parentStudyId) {

--- a/transmart-core-db/src/test/groovy/org/transmartproject/db/multidimquery/ConstraintSerialiserSpec.groovy
+++ b/transmart-core-db/src/test/groovy/org/transmartproject/db/multidimquery/ConstraintSerialiserSpec.groovy
@@ -1,0 +1,59 @@
+package org.transmartproject.db.multidimquery
+
+import org.transmartproject.db.multidimquery.query.*
+import org.transmartproject.db.ontology.I2b2Secure
+import org.transmartproject.db.tree.TreeNodeImpl
+import spock.lang.Specification
+
+import java.time.Instant
+
+class ConstraintSerialiserSpec extends Specification {
+
+    void 'test disjunction of concept constraints'() {
+        given: 'a disjunction and its expected serialised form'
+        Constraint constraint = new OrConstraint([
+                new ConceptConstraint('height'),
+                new ConceptConstraint('birthdate')
+        ])
+
+        String expected = '{"type":"or","args":[{"type":"concept","conceptCode":"height"},{"type":"concept","conceptCode":"birthdate"}]}'
+
+        when: 'serialising the constraint'
+        def result = ConstraintSerialiser.toJson(constraint)
+
+        then: 'the result is equal to the expected JSON'
+        result == expected
+    }
+
+    void 'test conjunction of study constraint and concept constraint'() {
+        given: 'a conjunction and its expected serialised form'
+        Constraint constraint = new AndConstraint([
+                new StudyNameConstraint('SURVEY1'),
+                new ConceptConstraint('height')
+        ])
+
+        String expected = '{"type":"and","args":[{"type":"study_name","studyId":"SURVEY1"},{"type":"concept","conceptCode":"height"}]}'
+
+        when: 'serialising the constraint'
+        def result = ConstraintSerialiser.toJson(constraint)
+
+        then: 'the result is equal to the expected JSON'
+        result == expected
+    }
+
+    void 'test date serialisation'() {
+        given: 'a time constraint'
+        String date = '2017-03-25T13:37:17.783Z'
+        Constraint constraint = new TimeConstraint(new Field('value', Type.NUMERIC, 'numValue'),
+                Operator.BEFORE, [Date.from(Instant.parse(date))])
+
+        String expected = '{"type":"time","field":{"dimension":"value","type":"NUMERIC","fieldName":"numValue"},"operator":"<-","values":["' + date + '"]}'
+
+        when: 'serialising the constraint'
+        def result = ConstraintSerialiser.toJson(constraint)
+
+        then: 'the constraint is properly serialised'
+        result == expected
+    }
+
+}

--- a/transmart-core-db/src/test/groovy/org/transmartproject/db/multidimquery/QueryRewriterSpec.groovy
+++ b/transmart-core-db/src/test/groovy/org/transmartproject/db/multidimquery/QueryRewriterSpec.groovy
@@ -4,8 +4,6 @@ import org.transmartproject.db.multidimquery.query.AndConstraint
 import org.transmartproject.db.multidimquery.query.CombinationConstraintRewriter
 import org.transmartproject.db.multidimquery.query.ConceptConstraint
 import org.transmartproject.db.multidimquery.query.Constraint
-import org.transmartproject.db.multidimquery.query.ConstraintSerialiser
-import org.transmartproject.db.multidimquery.query.Field
 import org.transmartproject.db.multidimquery.query.Negation
 import org.transmartproject.db.multidimquery.query.Operator
 import org.transmartproject.db.multidimquery.query.OrConstraint
@@ -13,13 +11,10 @@ import org.transmartproject.db.multidimquery.query.PatientSetConstraint
 import org.transmartproject.db.multidimquery.query.StudyNameConstraint
 import org.transmartproject.db.multidimquery.query.SubSelectionConstraint
 import org.transmartproject.db.multidimquery.query.TemporalConstraint
-import org.transmartproject.db.multidimquery.query.TimeConstraint
 import org.transmartproject.db.multidimquery.query.TrueConstraint
 import org.transmartproject.db.multidimquery.query.Type
 import org.transmartproject.db.multidimquery.query.ValueConstraint
 import spock.lang.Specification
-
-import java.time.Instant
 
 class QueryRewriterSpec extends Specification {
 
@@ -267,19 +262,6 @@ class QueryRewriterSpec extends Specification {
 
         then: 'the rewrite result is equal to the preferred form'
         result.toJson() == expected.toJson()
-    }
-
-    void 'test date serialisation'() {
-        given: 'a time constraint'
-        String date = '2017-03-25T13:37:17.783Z'
-        Constraint constraint = new TimeConstraint(new Field('value', Type.NUMERIC, 'numValue'),
-            Operator.BEFORE, [Date.from(Instant.parse(date))])
-
-        when: 'serialising the constraint'
-        def result = ConstraintSerialiser.toJson(constraint)
-
-        then: 'the constraint is properly serialised'
-        result == '{"type":"time","field":{"dimension":"value","type":"NUMERIC","fieldName":"numValue"},"operator":"<-","values":["' + date + '"]}'
     }
 
 }

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/TreeController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/TreeController.groovy
@@ -36,7 +36,7 @@ class TreeController {
      * @param root (Optional) the root element from which to fetch.
      * @param depth (Optional) the maximum number of levels to fetch.
      * @param constraints flag if the constraints should be included in the result
-     *   (always true for hal, defaults to true for json)
+     *   (always false for hal, defaults to true for json)
      * @param counts flag if counts should be included in the result (default: false)
      * @param tags flag if tags should be included in the result (default: false)
      *

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/TreeNodeMarshaller.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/marshallers/TreeNodeMarshaller.groovy
@@ -38,12 +38,8 @@ class TreeNodeMarshaller implements ObjectMarshaller<JSON> {
                 type:     obj.ontologyTermType.name(),
                 visualAttributes: obj.visualAttributes
         ] as Map<String, Object>
-        def constraint = obj.constraint
         if (obj.dimension) {
             result.dimension = obj.dimension
-        }
-        if (constraint) {
-            result.constraint = constraint
         }
         if (obj.study?.studyId) {
             result.studyId = obj.study?.studyId

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/TreeJsonSerializer.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/TreeJsonSerializer.groovy
@@ -43,7 +43,6 @@ class TreeJsonSerializer {
         if (node.conceptPath) {
             writer.name('conceptPath').value(node.conceptPath)
         }
-        writer.name('name').value(node.name)
         writer.name('type').value(node.ontologyTermType.name())
         writer.name('visualAttributes')
         writer.beginArray()
@@ -94,6 +93,7 @@ class TreeJsonSerializer {
         this.writeConstraints = args?.writeConstraints == null ? true : args?.writeConstraints
         this.writeTags = args?.writeTags ?: false
         writeNode(node)
+        writer.flush()
     }
 
     /**

--- a/transmart-rest-api/src/test/groovy/org/transmartproject/rest/serialization/TreeJsonSerializerSpec.groovy
+++ b/transmart-rest-api/src/test/groovy/org/transmartproject/rest/serialization/TreeJsonSerializerSpec.groovy
@@ -1,0 +1,43 @@
+package org.transmartproject.rest.serialization
+
+import org.transmartproject.core.ontology.OntologyTerm
+import org.transmartproject.db.ontology.I2b2Secure
+import org.transmartproject.db.tree.TreeNodeImpl
+import spock.lang.Specification
+
+class TreeJsonSerializerSpec extends Specification {
+
+    void 'test tree node constraint serialisation'() {
+        given:
+        def studyNode = Mock(I2b2Secure, {
+            getFullName() >> '\\Studies\\Survey 0\\'
+            getName() >> 'Survey 0'
+            getVisualAttributes() >> OntologyTerm.VisualAttributes.forSequence('FAS')
+            getDimensionTableName() >> 'study'
+            getColumnName() >> 'study_id'
+            getOperator() >> '='
+            getDimensionCode() >> 'SURVEY0'
+        })
+        def i2b2Node = Mock(I2b2Secure, {
+            getFullName() >> '\\Studies\\Survey 0\\Birth date\\'
+            getName() >> 'Birth date'
+            getVisualAttributes() >> OntologyTerm.VisualAttributes.forSequence('LAN')
+            getDimensionTableName() >> 'concept_dimension'
+            getColumnName() >> 'concept_cd'
+            getOperator() >> '='
+            getDimensionCode() >> 'birthdate'
+        })
+        def node = new TreeNodeImpl(i2b2Node, [])
+        def parentNode = new TreeNodeImpl(studyNode, [node])
+        node.conceptCode = 'birthdate'
+        node.parent = parentNode
+
+        when:
+        def out = new ByteArrayOutputStream()
+        new TreeJsonSerializer().write([writeConstraints: true, writeTags: false], node, out)
+
+        then:
+        out.toString() == '{"name":"Birth date","fullName":"\\\\Studies\\\\Survey 0\\\\Birth date\\\\","studyId":"SURVEY0","conceptCode":"birthdate","type":"NUMERIC","visualAttributes":["LEAF","ACTIVE","NUMERICAL"],"constraint":{"type":"and","args":[{"type":"concept","conceptCode":"birthdate"},{"type":"study_name","studyId":"SURVEY0"}]}}'
+    }
+
+}


### PR DESCRIPTION
Because of a Groovy bug, sometimes the static field of a superclass
is used instead of the static field in the subclass. This caused
'and' constraints to be serialised as 'combination' constraints.