### PR TITLE
Fix for transmart-batch to be able to load GWAS pvalue_cutoff metadata value

### DIFF
--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/metadata/GwasMetadataEntry.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/metadata/GwasMetadataEntry.groovy
@@ -5,6 +5,7 @@ import groovy.transform.ToString
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Pattern
 import javax.validation.constraints.Size
+import javax.validation.constraints.Digits
 
 /**
  * Represents a line in the GWAS metadata file.
@@ -79,8 +80,8 @@ class GwasMetadataEntry {
     @Size(max = 500)
     String cellType
 
-    @Size(max = 50)
-    String pvalueCutoff
+    @Digits(integer = 1, fraction = 10)
+    BigDecimal pvalueCutoff
 
     @Size(max = 500)
     String inputFile // INPUT_FILENAME in kettle


### PR DESCRIPTION
When using transmart-batch to load a GWAS dataset with an actual value for the pvalue_cutoff in the metadata file, it results in an error: `ERROR: column "pvalue_cutoff" is of type double precision but expression is of type character varying`

Proposed solution: Change the type of the pvalue_cutoff value to a BigDecimal.

The loading then runs without errors and the pvalue_cutoff value is loaded in the pvalue_cutoff column of biomart.bio_assay_analysis. (Tested with Postgres and the MAGIC dataset with a change in the metadata file to include a pvalue_cutoff value)