### PR TITLE
Fix mapping of extra GWAS columns in transmart-batch

### DIFF
--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/analysisdata/AssayAnalysisGwasWriter.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/analysisdata/AssayAnalysisGwasWriter.groovy
@@ -16,6 +16,7 @@ import org.transmartproject.batch.db.SequenceReserver
 import java.lang.reflect.Field
 import java.sql.PreparedStatement
 import java.sql.SQLException
+import java.sql.Types
 
 /**
  * Inserts rows into bio_assay_analysis_gwas.
@@ -55,8 +56,12 @@ class AssayAnalysisGwasWriter implements ItemWriter<GwasAnalysisRow> {
                     p_value_char,
                     p_value,
                     log_p_value,
+                    effect_allele,
+                    other_allele,
+                    standard_error,
+                    beta,
                     ext_data)
-                    VALUES(?, ?, ?, ?, ?, ?, ?)""",
+                    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 new AssayAnalysisGwasWriterPreparedStatementSetter(items: items)
 
         DatabaseUtil.checkUpdateCounts(affected,
@@ -87,7 +92,22 @@ class AssayAnalysisGwasWriter implements ItemWriter<GwasAnalysisRow> {
                 ps.setDouble 6, logPValue
             }
 
-            ps.setString 7, getExtData(row)
+            ps.setString 7, row.allele1
+            ps.setString 8, row.allele2
+            
+            if (row.standardError != null) {
+                ps.setDouble 9, row.standardError.toDouble()
+            } else {
+                ps.setNull 9, Types.DOUBLE
+            }
+
+            if (row.beta != null) {
+                ps.setDouble 10, row.beta.toDouble()
+            } else {
+                ps.setNull 10, Types.DOUBLE
+            }
+
+            ps.setString 11, getExtData(row)
         }
 
         @Override

--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/analysisdata/GwasAnalysisRow.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/analysisdata/GwasAnalysisRow.groovy
@@ -31,7 +31,7 @@ class GwasAnalysisRow {
     BigDecimal oddsRatio
 
     @Order(1)
-    String beta
+    BigDecimal beta
 
     @Order(2)
     String directionOfEffect

--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/analysisdata/UpdateGwasTop500Tasklet.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/analysisdata/UpdateGwasTop500Tasklet.groovy
@@ -55,7 +55,11 @@ class UpdateGwasTop500Tasklet implements Tasklet {
                      rnum,
                      intronexon,
                      recombinationrate,
-                     regulome)
+                     regulome,
+                     effect_allele,
+                     other_allele,
+                     standard_error,
+                     beta)
                 SELECT * FROM (
                     SELECT DISTINCT
                         :baa_id,
@@ -70,7 +74,11 @@ class UpdateGwasTop500Tasklet implements Tasklet {
                         row_number() OVER(ORDER BY DATA.p_value ASC, DATA.rs_id ASC) AS rnum,
                         INFO.exon_intron AS intronexon,
                         INFO.recombination_rate AS recombinationrate,
-                        INFO.regulome_score AS regulome
+                        INFO.regulome_score AS regulome,
+                        DATA.effect_allele AS effect_allele,
+                        DATA.other_allele AS other_allele,
+                        DATA.standard_error AS standard_error,
+                        DATA.beta AS beta
                     FROM
                         ${Tables.BIO_ASSAY_ANALYSIS_GWAS} DATA
                         LEFT JOIN ${Tables.RC_SNP_INFO} INFO


### PR DESCRIPTION
When loading GWAS data with transmart-batch: the values for alleles, standard_error and beta are not loaded in the corresponding columns in the database (biomart.bio_assay_analysis_gwas) and thus are not visible in the GWAS interface.

Proposed solution: update insert statement to include these columns

Tested with Postgres and the MAGIC dataset for which we have alleles and standard_error.