### PR TITLE
add hard threshold for GWAS quick search, fix GWAS performance for postgres

### DIFF
--- a/transmart-gwas-plugin/grails-app/controllers/com/recomdata/grails/plugin/gwas/GwasSearchController.groovy
+++ b/transmart-gwas-plugin/grails-app/controllers/com/recomdata/grails/plugin/gwas/GwasSearchController.groovy
@@ -307,7 +307,7 @@ class GwasSearchController {
         def columnNames = []
 
         def wasShortcut = false
-        if (!regions && !geneNames && !transcriptGeneNames && analysisIds.size() == 1 && sortField.equals('null') && !cutoff && !search && max > 0) {
+        if (!regions && !geneNames && !transcriptGeneNames && analysisIds.size() == 1 && sortField.equals('null') && !cutoff && !search && max > 0 && offset < 500) {
             println("Triggering shortcut query")
             wasShortcut = true
             //If displaying no regions and only one analysis, run the alternative query and pull back the rows for the limits


### PR DESCRIPTION
For GwasSearchController.groovy added a hard threshold (offset < 500). Reason for this is to be able to display a selection of observations greater than 500 in the GWAS analysis window without resolving to sort on an arbitrary column. For RegionSearchService, we have added SQL queries in postgreSQL, but kept the original Oracle SQL queries. Which queries to be used is conditional on the DB type. Main reason for change is performance when using a PostgreSQL DB. 