### PR TITLE
Add parallelisation parameters to application config.

### DIFF
--- a/transmart-core-db/grails-app/services/org/transmartproject/db/support/SystemService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/support/SystemService.groovy
@@ -1,5 +1,6 @@
 package org.transmartproject.db.support
 
+import grails.util.Holders
 import groovy.transform.CompileStatic
 import org.modelmapper.ModelMapper
 import org.springframework.beans.factory.annotation.Autowired
@@ -20,8 +21,8 @@ class SystemService implements SystemResource {
     private final int DEFAULT_PATIENT_SET_CHUNK_SIZE = 10000
 
     private final RuntimeConfigImpl runtimeConfig = new RuntimeConfigImpl(
-            Runtime.getRuntime().availableProcessors(),
-            DEFAULT_PATIENT_SET_CHUNK_SIZE
+            Holders.config.getProperty('org.transmartproject.system.numberOfWorkers', Integer.class, Runtime.getRuntime().availableProcessors()),
+            Holders.config.getProperty('org.transmartproject.system.patientSetChunkSize', Integer.class, DEFAULT_PATIENT_SET_CHUNK_SIZE)
     )
 
     private final ModelMapper modelMapper = new ModelMapper()

--- a/transmart-server/grails-app/conf/application.groovy
+++ b/transmart-server/grails-app/conf/application.groovy
@@ -70,6 +70,10 @@ grails.databinding.trimStrings = false
 // enabled native2ascii conversion of i18n properties files
 grails.enable.native2ascii = true
 
+// Runtime configuration for the parallel export and counting implementations.
+org.transmartproject.system.numberOfWorkers = Runtime.getRuntime().availableProcessors()
+org.transmartproject.system.patientSetChunkSize = 10000
+
 com.recomdata.skipdisclaimer = true
 
 //core-db settings


### PR DESCRIPTION
Number of workers and chunk size (number of patients for
a subtask) can now be configured from application.groovy.