### PR TITLE
Add support for hg38 in GWAS module

### DIFF
--- a/transmart-batch/docs/data_formats/gwas.md
+++ b/transmart-batch/docs/data_formats/gwas.md
@@ -10,7 +10,7 @@ Available Parameters
 - `DATA_LOCATION` _Default_: parent directory of the metadata file. The
   directory that functions as the path against which the data files
   referenced in the metadata file are to be found.
-- `HG_VERSION` _Default_: 19. Either 18 or 19. The reference assembly to use.
+- `HG_VERSION` _Default_: 19. Either 18, 19 or 38. The reference assembly to use.
 
 Metadata file
 -------------

--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/GwasParameterModule.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/GwasParameterModule.groovy
@@ -21,7 +21,7 @@ class GwasParameterModule implements ExternalJobParametersModule {
 
     private static final String DEFAULT_HG_VERSION = '19'
     private static final List<String> ALLOWED_HG_VERSIONS =
-            ImmutableList.of('18', '19')
+            ImmutableList.of('18', '19', '38')
 
     final Set<String> supportedParameters = ImmutableSet.of(
             DATA_LOCATION,

--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/metadata/GwasMetadataEntry.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/gwas/metadata/GwasMetadataEntry.groovy
@@ -53,7 +53,7 @@ class GwasMetadataEntry {
     @Size(max = 500)
     String tissue
 
-    @Pattern(regexp = '1[8-9]', message = '{supportedGenomeVersions}')
+    @Pattern(regexp = '1[8-9]|38', message = '{supportedGenomeVersions}')
     String genomeVersion
 
     @Size(max = 500)

--- a/transmart-gwas-plugin/grails-app/services/com/recomdata/grails/plugin/gwas/RegionSearchService.groovy
+++ b/transmart-gwas-plugin/grails-app/services/com/recomdata/grails/plugin/gwas/RegionSearchService.groovy
@@ -443,6 +443,9 @@ class RegionSearchService {
             if (hg19only) {
                 regionList.append("1=1")
             }
+            else if (grailsApplication.config.com.recomdata.gwas.usehg38table) {
+                regionList.append("info.hg_version = '38'")
+            }
             else {
                 regionList.append("info.hg_version = '19'")
             }

--- a/transmart-gwas-plugin/grails-app/views/GWAS/_regionFilter.gsp
+++ b/transmart-gwas-plugin/grails-app/views/GWAS/_regionFilter.gsp
@@ -8,7 +8,7 @@
 <g:radio name="regionFilter" value="gene"/> 
 Gene/RSID: <tmpl:/GWAS/extTagSearchField width="100" fieldName="filterGeneId" searchAction="searchAutoComplete" searchController="GWAS" />
 <br/><br/> <br/>
-Use: <g:select name="filterGeneUse" from="${['19':'HG19','18':'HG18']}" optionKey="${{it.key}}" optionValue="${{it.value}}"/>
+Use: <g:select name="filterGeneUse" from="${['19':'HG19','18':'HG18','38':'HG38']}" optionKey="${{it.key}}" optionValue="${{it.value}}"/>
 <br/><br/>
 Location: 
 <g:select name="filterGeneRange" from="${ranges}" optionKey="${{it.key}}" optionValue="${{it.value}}"/> <g:textField name="filterGeneBasePairs" style="width: 50px"/> base pairs</div>
@@ -20,7 +20,7 @@ Location:
 <div onclick="jQuery('[name=\'regionFilter\'][value=\'chromosome\']').attr('checked', true);">
 <g:radio name="regionFilter" value="chromosome"/> 
 Chromosome: <g:select name="filterChromosomeNumber" from="${1..23}"/> 
-Use: <g:select name="filterChromosomeUse" from="${['19':'HG19','18':'HG18']}" optionKey="${{it.key}}" optionValue="${{it.value}}"/>
+Use: <g:select name="filterChromosomeUse" from="${['19':'HG19','18':'HG18','38':'HG38']}" optionKey="${{it.key}}" optionValue="${{it.value}}"/>
 <br/><br/>
 Position: 
 <g:textField name="filterChromosomePosition" style="width: 100px"/>


### PR DESCRIPTION
The GWAS module currently supports only version 18 and 19 of the human genome build. In order to support the newer 38 version, two changes are needed:

1. update transmart-batch to support load of GWAS datasets using hg38
2. update GWAS plugin to be able to query GWAS datasets using hg38 (relying on an extra config param in Config.groovy if hg38 is to be used per default `com.recomdata.gwas.usehg38table = true`)