### PR TITLE
Add support for POST to /v2/dimensions/$dimensionName/elements endpoint

### DIFF
--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -2099,6 +2099,38 @@
             }
           }
         }
+      },
+      "post": {
+        "description": "Works the same as GET, but with support for longer constraints. Use this, if the total length of the URL may be longer than the maximum length.\n",
+        "tags": [
+          "v2"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "dimensionName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "constraint",
+            "required": false,
+            "in": "body",
+            "description": "json that specifies the constraint. Example: `{\"type\":\"concept\",\"path\":\"\\\\Public Studies\\\\EHR\\\\Vital Signs\\\\Heart Rate\\\\\"}`.",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns list of all elements from the given dimension that user has access to.\n",
+            "schema": {
+              "$ref": "#/definitions/dimensionElements"
+            }
+          }
+        }
       }
     },
     "/v2/export/job": {

--- a/open-api/swagger.yaml
+++ b/open-api/swagger.yaml
@@ -1792,6 +1792,29 @@ paths:
             Returns list of all elements from the given dimension that user has access to.
           schema:
             $ref: '#/definitions/dimensionElements'
+    post:
+      description: |
+        Works the same as GET, but with support for longer constraints. Use this, if the total length of the URL may be longer than the maximum length.
+      tags:
+        - v2
+      consumes:
+        - application/json
+      parameters:
+        - name: dimensionName
+          in: path
+          required: true
+          type: string
+        - name: constraint
+          required: false
+          in: body
+          description: 'json that specifies the constraint. Example: `{"type":"concept","path":"\\Public Studies\\EHR\\Vital Signs\\Heart Rate\\"}`.'
+          type: string
+      responses:
+        200:
+          description: |
+            Returns list of all elements from the given dimension that user has access to.
+          schema:
+            $ref: '#/definitions/dimensionElements'
   /v2/export/job:
     post:
       description: |

--- a/open-api/swagger_spec.js
+++ b/open-api/swagger_spec.js
@@ -2099,6 +2099,38 @@ var spec = {
             }
           }
         }
+      },
+      "post": {
+        "description": "Works the same as GET, but with support for longer constraints. Use this, if the total length of the URL may be longer than the maximum length.\n",
+        "tags": [
+          "v2"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "dimensionName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "constraint",
+            "required": false,
+            "in": "body",
+            "description": "json that specifies the constraint. Example: `{\"type\":\"concept\",\"path\":\"\\\\Public Studies\\\\EHR\\\\Vital Signs\\\\Heart Rate\\\\\"}`.",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns list of all elements from the given dimension that user has access to.\n",
+            "schema": {
+              "$ref": "#/definitions/dimensionElements"
+            }
+          }
+        }
       }
     },
     "/v2/export/job": {

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/DimensionController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/DimensionController.groovy
@@ -29,18 +29,18 @@ class DimensionController extends AbstractQueryController {
     
     /**
      * Dimension endpoint:
-     * <code>GET /v2/dimensions/${dimensionName}/elements</code>
+     * <code>/v2/dimensions/${dimensionName}/elements</code>
      *
      * @return a list of all dimension elements that user has access to.
      */
     def list(@PathVariable('dimensionName') String dimensionName) {
-
-        checkForUnsupportedParams(params, ['dimensionName', 'constraint'])
+        def args = getGetOrPostParams()
+        checkForUnsupportedParams(args, ['dimensionName', 'constraint'])
 
         User user = (User) usersResource.getUserFromUsername(currentUser.username)
         def dimension = getDimension(dimensionName, user)
 
-        Constraint constraint = Strings.isNullOrEmpty(params.constraint) ? new TrueConstraint() : bindConstraint(params.constraint)
+        Constraint constraint = Strings.isNullOrEmpty(args.constraint) ? new TrueConstraint() : bindConstraint(args.constraint)
 
         def results = multiDimService.getDimensionElements(dimension, constraint, user)
         render wrapElements(dimension, results) as JSON

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/RestApiUrlMappings.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/RestApiUrlMappings.groovy
@@ -164,7 +164,8 @@ class RestApiUrlMappings {
             "/arvados/workflows/$id"(method: 'PUT', controller: 'arvados', action: 'update') {
                 apiVersion = "v2"
             }
-            "/dimensions/$dimensionName/elements"(methos: 'GET', controller: 'dimension', action: 'list'){
+            "/dimensions/$dimensionName/elements"(controller: 'dimension') {
+                action = [GET: 'list', POST: 'list']
                 apiVersion = 'v2'
             }
             "/export/job"(method: 'POST', controller: 'export', action: 'createJob') {


### PR DESCRIPTION
This call accepts 'constraints' param, which can be longer, so it makes
sense to support POST here.