### PR TITLE
Fix convert date

### DIFF
--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/HypercubeJsonSerializer.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/HypercubeJsonSerializer.groovy
@@ -8,7 +8,9 @@ import org.transmartproject.core.multidimquery.Dimension
 import org.transmartproject.core.multidimquery.Hypercube
 import org.transmartproject.core.multidimquery.HypercubeValue
 
+import java.sql.Timestamp
 import java.time.Instant
+import java.time.ZoneId
 
 /**
  * <code>
@@ -164,6 +166,9 @@ class HypercubeJsonSerializer extends HypercubeSerializer {
             writer.nullValue()
         } else if (value instanceof String) {
             writer.value((String) value)
+        } else if (value instanceof Timestamp) {
+            def time = ((Timestamp)value).toLocalDateTime().atZone(ZoneId.of("GMT")).toInstant().toString()
+            writer.value(time)
         } else if (value instanceof Date) {
             def time = Instant.ofEpochMilli(((Date) value).time).toString()
             writer.value(time)


### PR DESCRIPTION
Rest request 

> /v2/observations?constraint={"type":"concept","path":"<path>"}&type=clinical 

return "startDate": "0000-12-30T00:00:00Z", but in db value is 0001-01-01 00:00:00 (Default value). 
Convert as 
def time = Instant.ofEpochMilli(((Date) value).time).toString()
is worked for normal date, but for very old date Instant is more strong and convert works wrong. 

