### PR TITLE
Revert accepting an OutputStream instead of ZipOutputStream

### DIFF
--- a/transmart-rest-api/grails-app/services/org/transmartproject/rest/DataTableViewDataSerializationService.groovy
+++ b/transmart-rest-api/grails-app/services/org/transmartproject/rest/DataTableViewDataSerializationService.groovy
@@ -69,7 +69,7 @@ class DataTableViewDataSerializationService implements DataSerializer {
                 tableArgs, 'clinical', constraint, user)
         try {
             log.info "Writing tabular data in ${format} format."
-            def serializer = new DataTableTSVSerializer(user, out)
+            def serializer = new DataTableTSVSerializer(user, (ZipOutputStream) out)
             serializer.writeDataTableToZip(datatable)
         } finally {
             datatable.close()

--- a/transmart-rest-api/grails-app/services/org/transmartproject/rest/SurveyTableViewDataSerializationService.groovy
+++ b/transmart-rest-api/grails-app/services/org/transmartproject/rest/SurveyTableViewDataSerializationService.groovy
@@ -60,12 +60,12 @@ class SurveyTableViewDataSerializationService implements DataSerializer {
 
     Set<Format> supportedFormats = [Format.TSV, Format.SPSS] as Set<Format>
 
-    TabularResultSerializer getSerializer(Format format, User user, OutputStream outputStream, ImmutableList<DataColumn> columns) {
+    TabularResultSerializer getSerializer(Format format, User user, ZipOutputStream zipOutputStream, ImmutableList<DataColumn> columns) {
         switch(format) {
             case Format.TSV:
-                return new TabularResultTSVSerializer(user, outputStream, columns)
+                return new TabularResultTSVSerializer(user, zipOutputStream, columns)
             case Format.SPSS:
-                return new TabularResultSPSSSerializer(user, outputStream, columns)
+                return new TabularResultSPSSSerializer(user, zipOutputStream, columns)
             default:
                 throw new UnsupportedOperationException("Unsupported format for tabular data: ${format}")
         }
@@ -123,7 +123,7 @@ class SurveyTableViewDataSerializationService implements DataSerializer {
             columns = surveyTableColumnService
                     .getMetadataAwareColumns(hypercubeColumns, includeMeasurementDateColumns)
         }
-        final TabularResultSerializer serializer = getSerializer(format, user, new ZipOutputStream(out),
+        final TabularResultSerializer serializer = getSerializer(format, user, (ZipOutputStream) out,
                 ImmutableList.copyOf(columns as List<DataColumn>))
         final patientDimension = multiDimService.getDimension('patient')
 

--- a/transmart-rest-api/grails-app/services/org/transmartproject/rest/dataExport/ExportService.groovy
+++ b/transmart-rest-api/grails-app/services/org/transmartproject/rest/dataExport/ExportService.groovy
@@ -47,7 +47,7 @@ class ExportService {
         return exportJobExecutor.getExportJobFileStream(job.viewerURL)
     }
 
-    def exportData(Map jobDataMap, OutputStream output) {
+    def exportData(Map jobDataMap, ZipOutputStream output) {
 
         List<Map> dataTypeAndFormatList = jobDataMap.dataTypeAndFormatList.flatten()
         org.transmartproject.core.users.User user = jobDataMap.user

--- a/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/DataTableViewDataSerializationServiceSpec.groovy
+++ b/transmart-rest-api/src/integration-test/groovy/org/transmartproject/rest/DataTableViewDataSerializationServiceSpec.groovy
@@ -24,6 +24,7 @@ import spock.lang.Specification
 
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
 
 @FreshRuntime
 @Rollback
@@ -54,13 +55,14 @@ class DataTableViewDataSerializationServiceSpec extends Specification {
         setupData()
 
         def file = new ByteArrayOutputStream()
+        def zipFile = new ZipOutputStream(file)
         Constraint constraint = new StudyObjectConstraint(study: clinicalData.longitudinalStudy)
         Map config = [
                 rowDimensions: ['study', 'patient'],
                 columnDimensions: ['trial visit', 'concept'],
         ]
 
-        serializationService.writeClinical(Format.TSV, constraint, adminUser, file, [tableConfig: config])
+        serializationService.writeClinical(Format.TSV, constraint, adminUser, zipFile, [tableConfig: config])
         def files = parseTSVZip(file)
 
         expect:
@@ -121,7 +123,8 @@ class DataTableViewDataSerializationServiceSpec extends Specification {
 
     List<List<String>> roundTrip(Dimension dim, List elements) {
         def file = new ByteArrayOutputStream()
-        def serializer = new DataTableTSVSerializer(adminUser, file)
+        def zipFile = new ZipOutputStream(file)
+        def serializer = new DataTableTSVSerializer(adminUser, zipFile)
 
         serializer.zipOutStream.putNextEntry(new ZipEntry(dim.name))
         serializer.writeDimensionElements(dim, elements)

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/dataExport/ExportJobExecutor.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/dataExport/ExportJobExecutor.groovy
@@ -22,7 +22,7 @@ class ExportJobExecutor implements InterruptableJob, AutoCloseable {
     ExportAsyncJobService asyncJobService = ctx.exportAsyncJobService
     PersistenceContextInterceptor interceptor = ctx.persistenceInterceptor
 
-    FileOutputStream zipFile
+    ZipOutputStream zipFile
 
     @Override
     void execute(JobExecutionContext jobExecutionContext) {
@@ -45,7 +45,7 @@ class ExportJobExecutor implements InterruptableJob, AutoCloseable {
         String jobName = jobDataMap.jobName
         User user = jobDataMap.user
         String file = getFilePath(user, "${jobName}.zip")
-        zipFile = new FileOutputStream(file)
+        zipFile = new ZipOutputStream(new FileOutputStream(file))
         asyncJobService.updateStatus(jobId, JobStatus.GATHERING_DATA)
         exportService.exportData(jobDataMap, zipFile)
         asyncJobService.updateStatus(jobId, JobStatus.COMPLETED, file.toString())

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/tabular/AbstractTSVSerializer.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/tabular/AbstractTSVSerializer.groovy
@@ -16,9 +16,9 @@ class AbstractTSVSerializer {
     final User user
     final ZipOutputStream zipOutStream
 
-    AbstractTSVSerializer(User user, OutputStream outputStream) {
+    AbstractTSVSerializer(User user, ZipOutputStream zipOutputStream) {
         this.user = user
-        this.zipOutStream = new ZipOutputStream(outputStream)
+        this.zipOutStream = zipOutputStream
     }
 
     protected String[] formatRowValues(List<? extends Object> valuesRow) {

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/tabular/TabularResultSPSSSerializer.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/tabular/TabularResultSPSSSerializer.groovy
@@ -278,9 +278,9 @@ class TabularResultSPSSSerializer implements TabularResultSerializer {
      * will be used for temporary files.
      * @param zipOutStream the stream to write to.
      */
-    TabularResultSPSSSerializer(User user, OutputStream outputStream, ImmutableList<DataColumn> columns) {
+    TabularResultSPSSSerializer(User user, ZipOutputStream zipOutputStream, ImmutableList<DataColumn> columns) {
         this.user = user
-        this.zipOutputStream = new ZipOutputStream(outputStream)
+        this.zipOutputStream = zipOutputStream
         if (!columns) {
             throw new IllegalArgumentException("Can't write spss files for empty table.")
         }

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/tabular/TabularResultTSVSerializer.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/tabular/TabularResultTSVSerializer.groovy
@@ -12,6 +12,7 @@ import org.transmartproject.core.users.User
 import org.transmartproject.rest.dataExport.WorkingDirectory
 
 import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 @Slf4j
 @CompileStatic
@@ -74,8 +75,8 @@ class TabularResultTSVSerializer extends AbstractTSVSerializer implements Tabula
     final File workingDir
     final SortedMap<Integer, File> dataFiles = Collections.synchronizedSortedMap([:] as TreeMap)
 
-    TabularResultTSVSerializer(User user, OutputStream outStream, ImmutableList<DataColumn> columns) {
-        super(user, outStream)
+    TabularResultTSVSerializer(User user, ZipOutputStream zipOutStream, ImmutableList<DataColumn> columns) {
+        super(user, zipOutStream)
         this.columns = columns
         this.workingDir = WorkingDirectory.createDirectoryUser(user, 'transmart-tsv-', '-tmpdir')
     }

--- a/transmart-rest-api/src/test/groovy/org/transmartproject/rest/serialization/tabular/TabularResultTSVSerializerSpec.groovy
+++ b/transmart-rest-api/src/test/groovy/org/transmartproject/rest/serialization/tabular/TabularResultTSVSerializerSpec.groovy
@@ -15,6 +15,7 @@ import org.transmartproject.db.multidimquery.StudyDimension
 import spock.lang.Specification
 
 import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
 
 import static org.transmartproject.core.multidimquery.Dimension.Density.DENSE
 import static org.transmartproject.core.multidimquery.Dimension.Packable.NOT_PACKABLE
@@ -35,7 +36,8 @@ class TabularResultTSVSerializerSpec extends Specification {
      */
     def 'test TSV serialisation for tabular data'() {
         def user = Mock(User)
-        def out = new ByteArrayOutputStream()
+        ByteArrayOutputStream bout = new ByteArrayOutputStream()
+        def out = new ZipOutputStream(bout)
         def column1 = new HypercubeDataColumn(ImmutableMap.copyOf([(STUDY): 'studyA', (CONCEPT): 'age']))
         def column2 = new HypercubeDataColumn(ImmutableMap.copyOf([(STUDY): 'studyB', (CONCEPT): 'age']))
         def column3 = new HypercubeDataColumn(ImmutableMap.copyOf([(STUDY): 'studyA', (CONCEPT): 'height']))
@@ -72,7 +74,7 @@ class TabularResultTSVSerializerSpec extends Specification {
         out.flush()
 
         then:
-        def bytes = new ByteArrayInputStream(out.toByteArray())
+        def bytes = new ByteArrayInputStream(bout.toByteArray())
         def zipIn = new ZipInputStream(bytes)
         def entry = zipIn.nextEntry
         entry.name == 'data.tsv'


### PR DESCRIPTION
Fix TMT-210

Using FileOutputStream instead of ZipOutputStream in the
ExportJobExecutor was introduced in this commit:
https://github.com/thehyve/transmart-
core/commit/54766f9c9f9f2063c2c8472cbb97f18666e3afc3

This caused issues with closing the ZipOutputStream. The stream has to
be closed not only after the export job is done, but also when there are
some errors or job is interupted on purpose. This is problematic when
the FileOutputStream is wrapped in ZipOutputStream somewhere else than
ExportJobExecutor. Reverting the change was the easiest solution.