### PR TITLE
ERROR:  requested length too large

### DIFF
--- a/transmart-data/ddl/postgres/biomart_user/_cross.sql
+++ b/transmart-data/ddl/postgres/biomart_user/_cross.sql
@@ -277,6 +277,7 @@ CREATE VIEW biomart_user.folder_study_mapping AS
   WHERE (map.unique_id IS NOT NULL);
 
 -- transmart-core/transmart-data/ddl/postgres is the working directory for the code that executes this sql script.
+\i biomart_user/functions/scale_bitset.sql
 \i biomart_user/views/patient_num_boundaries.sql
 \i biomart_user/materialized_views/study_concept_bitset.sql
 \i biomart_user/views/patient_set_bitset.sql

--- a/transmart-data/ddl/postgres/biomart_user/functions/scale_bitset.sql
+++ b/transmart-data/ddl/postgres/biomart_user/functions/scale_bitset.sql
@@ -1,0 +1,27 @@
+--
+-- Name: scale_bitset(bigint); Type: FUNCTION; Schema: biomart_user; Owner: -
+--
+CREATE OR REPLACE FUNCTION biomart_user.scale_bitset(min_digits bigint) RETURNS bit varying
+    LANGUAGE plpgsql IMMUTABLE STRICT
+    AS $_$
+declare
+        result_buffer bit varying;
+        digits_in_buffer bigint;
+begin
+        digits_in_buffer := 1;
+        result_buffer := B'0';
+        WHILE digits_in_buffer < min_digits LOOP
+        	result_buffer := bitcat(result_buffer, result_buffer);
+        	digits_in_buffer := digits_in_buffer * 2;
+        END LOOP;
+        return result_buffer;
+end;
+$_$;
+
+DO $$
+BEGIN
+  ASSERT length(biomart_user.scale_bitset(1)) = 1, 'scale_bitset(1) has to return 1.';
+  ASSERT length(biomart_user.scale_bitset(100)) = 128, 'scale_bitset(100) has to return 128.';
+  ASSERT length(biomart_user.scale_bitset(1073741824)) = 1073741824, 'scale_bitset(1073741824) has to return 1073741824 (maximum it could deal with, 2^30).';
+  RAISE NOTICE 'scale_bitset tests have passed successfully.';
+END$$;

--- a/transmart-data/ddl/postgres/biomart_user/views/patient_num_boundaries.sql
+++ b/transmart-data/ddl/postgres/biomart_user/views/patient_num_boundaries.sql
@@ -8,5 +8,5 @@ SELECT MIN(patient_num) AS min_patient_num, MAX(patient_num) as max_patient_num 
 SELECT
   boundaries.min_patient_num,
   boundaries.max_patient_num,
-  lpad('1', (boundaries.max_patient_num - boundaries.min_patient_num + 1)::integer, '0')::bit varying AS one
+  bitcat(biomart_user.scale_bitset((boundaries.max_patient_num - boundaries.min_patient_num + 1)::bigint), B'1') AS one
 FROM boundaries;

--- a/transmart-data/updatedb/release-17.1-HYVE-4/postgres/migrate.sql
+++ b/transmart-data/updatedb/release-17.1-HYVE-4/postgres/migrate.sql
@@ -1,4 +1,5 @@
 -- subject bitset counts resources
+\i ../../../ddl/postgres/biomart_user/functions/scale_bitset.sql
 \i ../../../ddl/postgres/biomart_user/views/patient_num_boundaries.sql
 \i ../../../ddl/postgres/biomart_user/materialized_views/study_concept_bitset.sql
 \i ../../../ddl/postgres/biomart_user/views/patient_set_bitset.sql


### PR DESCRIPTION
use bit_cat instead lpad to form a bit string with a sufficient number of digits.
