### PR TITLE
Fix PostgreSQL limitation for IN query

### DIFF
--- a/transmart-core-db-tests/src/test/groovy/org/transmartproject/db/support/InQueryTest.groovy
+++ b/transmart-core-db-tests/src/test/groovy/org/transmartproject/db/support/InQueryTest.groovy
@@ -3,31 +3,63 @@ import spock.lang.Specification
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.*
+import static org.transmartproject.db.support.DatabasePortabilityService.DatabaseType.ORACLE
+import static org.transmartproject.db.support.DatabasePortabilityService.DatabaseType.POSTGRESQL
 
 class InQueryTest extends Specification {
 
-    void testNumOfItemsLessThenMax() {
+    void testLessThenMaxOracle() {
+        def dbType = ORACLE
         when:
-        def choppedList = InQuery.collateValues([1, 2, 3])
+        def choppedList = InQuery.collateValues([1, 2, 3], dbType)
         then:
         assertThat choppedList, hasSize(1)
         assertThat choppedList[0], contains(1, 2, 3)
     }
 
-    void testNumOfItemsMoreThenMax() {
+    void testMoreThenMaxOracle() {
+        def dbType = ORACLE
         when:
-        def choppedList = InQuery.collateValues((1..2500).toList())
+        def choppedList = InQuery.collateValues((1..2500).toList(), dbType)
         then:
         assertThat choppedList, hasSize(3)
         assertThat choppedList[0], hasSize(1000)
         assertThat choppedList[1], hasSize(1000)
         assertThat choppedList[2], hasSize(500)
-
     }
 
-    void testEmptyIds() {
+    void testEmptyIdsOracle () {
+        def dbType = ORACLE
         when:
-        def choppedList = InQuery.collateValues([[]])
+        def choppedList = InQuery.collateValues([[]], dbType)
+        then:
+        assertThat choppedList[0][0], hasSize(0)
+    }
+
+    void testLessThenMaxPostgreSQL() {
+        def dbType = POSTGRESQL
+        when:
+        def choppedList = InQuery.collateValues([1, 2, 3], dbType)
+        then:
+        assertThat choppedList, hasSize(1)
+        assertThat choppedList[0], contains(1, 2, 3)
+    }
+
+    void testMoreThenMaxPostgreSQL() {
+        def dbType = POSTGRESQL
+        when:
+        def choppedList = InQuery.collateValues((1..65600).toList(), dbType)
+        then:
+        assertThat choppedList, hasSize(3)
+        assertThat choppedList[0], hasSize(32760)
+        assertThat choppedList[1], hasSize(32760)
+        assertThat choppedList[2], hasSize(80)
+    }
+
+    void testEmptyIdsPostgreSQL () {
+        def dbType = POSTGRESQL
+        when:
+        def choppedList = InQuery.collateValues([[]], dbType)
         then:
         assertThat choppedList[0][0], hasSize(0)
     }


### PR DESCRIPTION
Similar as for Oracle (limit = 1000), but the limit for PostgreSQL is 32767 items in 'IN' query

[TMT-155](https://jira.thehyve.nl/browse/TMT-155)