### PR TITLE
Fix crossTable e2e tests, ignore canceling job test

### DIFF
--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/CrossTableSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/CrossTableSpec.groovy
@@ -43,13 +43,16 @@ class CrossTableSpec extends RESTSpec {
                                     toJSON([type: TrueConstraint])],
                 subjectConstraint: toJSON(type: PatientSetConstraint, patientSetId: patientSetId),
         ]
+
         def request = [
                 path      : PATH_CROSSTABLE,
                 acceptType: JSON,
-                user      : ADMIN_USER
+                user      : ADMIN_USER,
+                body      : params
         ]
+
         when: "I specify a list of row and column constraints and their intersections create table cells"
-        def responseData = getOrPostRequest(method, request, params)
+        def responseData = post(request)
 
         then: "for each of cells the number of subjects is computed properly"
         assert responseData.rows.size() == 2
@@ -59,7 +62,7 @@ class CrossTableSpec extends RESTSpec {
         when: "I do not have an access to the specified patient set"
         def request2 = request
         request2.user = DEFAULT_USER
-        def responseData2 = getOrPostRequest(method, request2, params)
+        def responseData2 = post(request2)
 
         then: "Returned counts for all cells equal zero"
         assert responseData2.rows.size() == 2
@@ -88,17 +91,13 @@ class CrossTableSpec extends RESTSpec {
         def subjectConstraint2 = toJSON(type: PatientSetConstraint, patientSetId: patientSetId2)
         def params2 = params
         params2.subjectConstraint = subjectConstraint2
-        def responseData3 = getOrPostRequest(method, request2, params2)
+        request2.body = params2
+        def responseData3 = post(request2)
 
         then: "Returned count for the first cell equals zero"
         assert responseData3.rows.size() == 2
         assert responseData3.rows[0] == [0, 5]
         assert responseData3.rows[1] == [0, 3]
-
-        where:
-        method | _
-        "POST" | _
-        "GET"  | _
     }
 
 }

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/DataExportSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/DataExportSpec.groovy
@@ -3,6 +3,7 @@ package tests.rest.v2
 import annotations.RequiresStudy
 import base.RESTSpec
 import groovy.util.logging.Slf4j
+import org.junit.Ignore
 
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
@@ -552,6 +553,12 @@ class DataExportSpec extends RESTSpec {
         return [jobName: jobId, downloadResponse: downloadResponse]
     }
 
+    /**
+     * This test fails randomly, because sometimes job runs too fast and it is already completed
+     * while the test is trying to cancel it
+     * Fix will be covered by: https://jira.thehyve.nl/browse/TMT-301
+     */
+    @Ignore
     @RequiresStudy(CATEGORICAL_VALUES_ID)
     def "cancel job"() {
         def patientSetRequest = [


### PR DESCRIPTION
Fix for DataExport."cancel job" will be covered by:
https://jira.thehyve.nl/browse/TMT-301