### PR TITLE
Temporarily ignore randomly failing ChildProcessAppender test

### DIFF
--- a/transmart-rest-api/src/test/groovy/org/transmartproject/rest/logging/ChildProcessAppenderTests.groovy
+++ b/transmart-rest-api/src/test/groovy/org/transmartproject/rest/logging/ChildProcessAppenderTests.groovy
@@ -25,6 +25,7 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import ch.qos.logback.classic.Level
 import org.slf4j.LoggerFactory
+import spock.lang.Ignore
 import spock.lang.Specification
 
 import java.nio.charset.StandardCharsets
@@ -101,6 +102,11 @@ class ChildProcessAppenderTests extends Specification {
         thrown ChildFailedException
     }
 
+    /**
+     * This test is failing randomly on Travis, so is temporarily ignored.
+     * The fix will be covered by: https://jira.thehyve.nl/browse/TMT-318.
+     */
+    @Ignore
     void testRestart() {
         when:
         def output = do_testRestart(3, 15)


### PR DESCRIPTION
@gijskant @forus There is one rest-api test for ChildProcessAppender (I kept it from a previous implementation that was using log4j specific libraries) that is failing randomly on dev (Travis). I am not sure why, because it is passing locally and was passing for the PR on Travis: https://github.com/thehyve/transmart-core/pull/247. Started failing after merge of this PR. I restarted rest-api tests couple of times and it is passing again. I need some time to investigate it, so as not to break future builds I would like to temporarily ignore it until I fix it.