### PR TITLE
Fix build of pg_bitcount on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
 env:
   global:
     - TERM=dumb
+    - PGCONFIG_PARAMS="PG_CONFIG=/usr/lib/postgresql/9.6/bin/pg_config"
   matrix:
     - DIR=transmart-core-api; TEST=check
     - DIR=transmart-core-db-tests; PREPARE=assemble; TEST=check

--- a/transmart-data/ddl/postgres/GLOBAL/Makefile
+++ b/transmart-data/ddl/postgres/GLOBAL/Makefile
@@ -94,8 +94,8 @@ pg_bitcount-master: pg_bitcount-master.tar.gz
 	tar -xvzf pg_bitcount-master.tar.gz
 
 install_pg_bitcount: pg_bitcount-master postgresql-server-dev-all
-	$(MAKE) -C pg_bitcount-master PG_CONFIG=`pg_config --bindir`/pg_config
-	sudo $(MAKE) -C pg_bitcount-master PG_CONFIG=`pg_config --bindir`/pg_config install
+	$(MAKE) -C pg_bitcount-master $(PGCONFIG_PARAMS)
+	sudo $(MAKE) -C pg_bitcount-master $(PGCONFIG_PARAMS) install
 
 pg_bitcount_extension: install_pg_bitcount
 	$(PSQL_COMMAND_NO_TRANSACTION) -d $(PGDATABASE) -c "CREATE EXTENSION IF NOT EXISTS pg_bitcount;"


### PR DESCRIPTION
When installing on another PostgreSQL database than the
system default, the proper pg_config binary should be
configured.