### PR TITLE
Fix audit logging for patient set creation.

### DIFF
--- a/transmart-core-db/grails-app/services/org/transmartproject/db/support/SystemService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/support/SystemService.groovy
@@ -114,7 +114,7 @@ class SystemService implements SystemResource {
     Map<String, Runnable> updateTasks = [
             'clear caches': { ->
                 clearCaches() } as Runnable,
-            'clear patient set bitset': { ->
+            'refresh study concept bitset materialized view': { ->
                 aggregateDataOptimisationsService.clearPatientSetBitset() } as Runnable,
             'clear patient sets': { ->
                 patientSetService.clearPatientSets() } as Runnable,

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/PatientQueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/PatientQueryController.groovy
@@ -8,6 +8,7 @@ import grails.converters.JSON
 import grails.web.mime.MimeType
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
+import org.transmartproject.core.binding.BindingHelper
 import org.transmartproject.core.dataquery.Patient
 import org.transmartproject.core.exceptions.InvalidArgumentsException
 import org.transmartproject.core.exceptions.InvalidRequestException
@@ -129,10 +130,10 @@ class PatientQueryController extends AbstractQueryController {
 
     /**
      * Patient set creation endpoint:
-     * <code>POST /v2/patient_sets?constraint=${constraint}&name=${name}&reuse=${reuse}</code>
+     * <code>POST /v2/patient_sets?name=${name}&reuse=${reuse}</code>
      *
      * Creates a patient set ({@link org.transmartproject.core.querytool.QueryResult}) based on
-     * the {@link Constraint} parameter <code>constraint</code>.
+     * the request body of type {@link Constraint}.
      *
      * @param apiVersion
      * @param name
@@ -164,7 +165,8 @@ class PatientQueryController extends AbstractQueryController {
 
         // FIXME: we now expect a plain constraint in the body, this should be wrapped in a {"constraint": ...} wrapper
         // for consistency with other calls
-        Constraint constraint = getConstraintFromString(request.reader.text)
+        def src = BindingHelper.objectMapper.writeValueAsString(request.JSON)
+        Constraint constraint = getConstraintFromString(src)
         if (constraint == null) {
             throw new InvalidArgumentsException("No valid constraint in the body.")
         }

--- a/transmart-rest-api/src/func-test/groovy/org/transmartproject/rest/v2/ApiAuditInterceptorSpec.groovy
+++ b/transmart-rest-api/src/func-test/groovy/org/transmartproject/rest/v2/ApiAuditInterceptorSpec.groovy
@@ -138,12 +138,12 @@ class ApiAuditInterceptorSpec extends V2ResourceSpec {
         logEntries.size() == 1
 
         where:
-        method  | action                | body
-        GET     | "/patients"           | null
-        GET     | "/patients/123"       | null
-        GET     | "/patient_sets/123"   | null
-        GET     | "/patient_sets"       | null
-        POST    | "/patient_sets"       | [:]
+        method  | action                                     | body
+        GET     | "/patients"                                | null
+        GET     | "/patients/123"                            | null
+        GET     | "/patient_sets/123"                        | null
+        GET     | "/patient_sets"                            | null
+        POST    | "/patient_sets?name=test&reuse=true"       | [type: 'negation', arg: [type: 'true']]
     }
 
     @Unroll


### PR DESCRIPTION
Got this error:
```
Aug 01 15:58:59 transmart-luke-xl start[21557]: 2018-08-01 15:58:59.642 ERROR --- [nio-8080-exec-3] o.t.interceptors.ApiAuditInterceptor     : Cannot read body for request /v2/patient_sets?name=temp&reuse=true: getReader() has already been called for this request
Aug 01 15:58:59 transmart-luke-xl start[21557]: Try to use request.inputStream instead of request.reader.
Aug 01 15:58:59 transmart-luke-xl start[21557]: 2018-08-01 15:58:59.644 TRACE --- [nio-8080-exec-3] o.t.db.log.AccessLogService              : {"username":"1ca384fd-4bb3-40f4-a88e-2330b2568d7d","event":"patientQuery request","eventMessage":"{\"ip\":\"91.206.81.2\",\"action\":\"createPatientSet\",\"duration\":22,\"status\":201}","requestURL":"/v2/patient_sets?name=temp&reuse=true","accessTime":"2018-08-01T15:58:59"}
```
This should fix it.