### PR TITLE
Use application cache to reuse patient sets.

### DIFF
--- a/open-api/swagger.json
+++ b/open-api/swagger.json
@@ -2658,7 +2658,7 @@
     },
     "/v2/admin/system/after_data_loading_update": {
       "get": {
-        "description": "This endpoint should be called after loading, deleting or updating data in the database. Clears tree nodes, counts caches, patient sets and bitsets. Updates data for subscribed user queries.\nOnly for administrators.\n",
+        "description": "This endpoint should be called after loading, deleting or updating data in the database.\nIt does different cache levels recalculations. Clears tree nodes, counts and patient set ids caches. Refreshes the bitsets materialized view. Updates data for subscribed user queries.\nOnly for administrators.\n",
         "tags": [
           "v2",
           "admin"

--- a/open-api/swagger.yaml
+++ b/open-api/swagger.yaml
@@ -2243,7 +2243,8 @@ paths:
   /v2/admin/system/after_data_loading_update:
     get:
       description: |
-        This endpoint should be called after loading, deleting or updating data in the database. Clears tree nodes, counts caches, patient sets and bitsets. Updates data for subscribed user queries.
+        This endpoint should be called after loading, deleting or updating data in the database.
+        It does different cache levels recalculations. Clears tree nodes, counts and patient set ids caches. Refreshes the bitsets materialized view. Updates data for subscribed user queries.
         Only for administrators.
       tags:
         - v2

--- a/open-api/swagger_spec.js
+++ b/open-api/swagger_spec.js
@@ -2658,7 +2658,7 @@ var spec = {
     },
     "/v2/admin/system/after_data_loading_update": {
       "get": {
-        "description": "This endpoint should be called after loading, deleting or updating data in the database. Clears tree nodes, counts caches, patient sets and bitsets. Updates data for subscribed user queries.\nOnly for administrators.\n",
+        "description": "This endpoint should be called after loading, deleting or updating data in the database.\nIt does different cache levels recalculations. Clears tree nodes, counts and patient set ids caches. Refreshes the bitsets materialized view. Updates data for subscribed user queries.\nOnly for administrators.\n",
         "tags": [
           "v2",
           "admin"

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/PatientSetResource.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/PatientSetResource.groovy
@@ -35,7 +35,7 @@ interface PatientSetResource {
      * @param constraint the constraint used in the lookup.
      * @return the query result if it exists; null otherwise.
      */
-    QueryResult findQueryResultByConstraint(User user, Constraint constraint)
+    QueryResult findFinishedQueryResultInCacheBy(User user, Constraint constraint)
 
     /**
      * Retrieves all query results for a user.

--- a/transmart-core-db-tests/src/integration-test/groovy/org/transmartproject/db/multidimquery/QueryServiceSpec.groovy
+++ b/transmart-core-db-tests/src/integration-test/groovy/org/transmartproject/db/multidimquery/QueryServiceSpec.groovy
@@ -20,9 +20,7 @@ import org.transmartproject.core.multidimquery.HypercubeValue
 import org.transmartproject.core.multidimquery.MultiDimensionalDataResource
 import org.transmartproject.core.multidimquery.query.*
 import org.transmartproject.core.querytool.QueryResultType
-import org.transmartproject.db.StudyTestData
 import org.transmartproject.db.TestData
-import org.transmartproject.db.dataquery.clinical.ClinicalTestData
 import spock.lang.Specification
 import org.transmartproject.db.i2b2data.ConceptDimension
 import org.transmartproject.db.i2b2data.ObservationFact

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/AggregateDataService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/AggregateDataService.groovy
@@ -181,7 +181,7 @@ class AggregateDataService extends AbstractDataResourceService implements Aggreg
             def constraintParts = ParallelPatientSetTaskService.getConstraintParts(constraint)
             if (!constraintParts.patientSetConstraint || !constraintParts.patientSetConstraint.patientSetId) {
                 // Try to combine the constraint a patient set for all accessible patients
-                def allPatientsSet = patientSetResource.findQueryResultByConstraint(
+                def allPatientsSet = patientSetResource.findFinishedQueryResultInCacheBy(
                         user, new TrueConstraint())
                 if (allPatientsSet) {
                     // add patient set constraint

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/PatientSetService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/PatientSetService.groovy
@@ -766,7 +766,7 @@ class PatientSetService extends AbstractDataResourceService implements PatientSe
     }
 
     private Object calculateCacheKey(User user, Constraint constraint) {
-        [user.username, constraint]
+        [user.username, constraint.toJson()]
     }
 
     private Cache getQueryResultIdsCache() {

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/PatientSetService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/PatientSetService.groovy
@@ -741,7 +741,7 @@ class PatientSetService extends AbstractDataResourceService implements PatientSe
 
     /**
      * Get's query result id (aka patient set id) for the given user and constraint from the cache.
-     * The cache meant to be cleaned after the data loading. {@see clearPatientSetIdsCache}
+     * The cache meant to be cleaned after the data loading. {@link this.clearPatientSetIdsCache()}
      * @param user user result belongs to
      * @param constraint constraint used in the query
      * @return query result id (aka patient set id)

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/support/SystemService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/support/SystemService.groovy
@@ -116,8 +116,8 @@ class SystemService implements SystemResource {
                 clearCaches() } as Runnable,
             'refresh study concept bitset materialized view': { ->
                 aggregateDataOptimisationsService.clearPatientSetBitset() } as Runnable,
-            'clear patient sets': { ->
-                patientSetService.clearPatientSets() } as Runnable,
+            'clear patient set ids cache': { ->
+                patientSetService.clearPatientSetIdsCache() } as Runnable,
             'user query set scan': { ->
                 userQuerySetResource.scan() } as Runnable,
             'rebuild caches': { ->

--- a/transmart-data/ddl/postgres/i2b2demodata/qt_query_master.sql
+++ b/transmart-data/ddl/postgres/i2b2demodata/qt_query_master.sql
@@ -40,11 +40,6 @@ ALTER TABLE ONLY qt_query_master
 CREATE INDEX qt_idx_qm_ugid ON qt_query_master USING btree (user_id, group_id, master_type_cd);
 
 --
--- Name: qt_query_master_request_constraints; Type: INDEX; Schema: i2b2demodata; Owner: -
---
-CREATE INDEX qt_query_master_request_constraints ON qt_query_master USING hash (request_constraints);
-
---
 -- add documentation
 --
 COMMENT ON TABLE i2b2demodata.qt_query_master IS 'This master table to the holds the client’s anaysis request information. i.e.

--- a/transmart-data/updatedb/release-17.1-HYVE-5/postgres/migrate_bitset.sql
+++ b/transmart-data/updatedb/release-17.1-HYVE-5/postgres/migrate_bitset.sql
@@ -1,2 +1,4 @@
 \i ../../../ddl/postgres/biomart_user/views/patient_num_boundaries.sql
 \i ../../../ddl/postgres/biomart_user/views/patient_set_bitset.sql
+
+drop index i2b2demodata.qt_query_master_request_constraints;


### PR DESCRIPTION
- Don't use database field for that. Doesn't work for oracle as it has clob that you could not apply indexes on. Use the application cache instead.
- Don't reuse query master objects at all.