### PR TITLE
Fix after data loading call empties s.&.c. counts

### DIFF
--- a/transmart-core-db/grails-app/services/org/transmartproject/db/tree/TreeService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/tree/TreeService.groovy
@@ -202,10 +202,6 @@ class TreeService implements TreeResource {
                 aggregateDataService.rebuildCountsCacheForBookmarkedUserQueries(user)
                 stopWatch.stop()
             }
-            stopWatch.start('Rebuild the counts per study and concept cache')
-            // Rebuild cache of counts per study and concept for the given user
-            aggregateDataService.rebuildCountsPerStudyAndConceptCache(fakeUsers)
-            stopWatch.stop()
             log.info "Done rebuilding the cache.\n${stopWatch.prettyPrint()}"
         } catch (Exception e) {
             log.error "Unexpected error while rebuilding cache: ${e.message}", e

--- a/transmart-rest-api-e2e/src/test/groovy/config/Config.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/config/Config.groovy
@@ -84,6 +84,10 @@ class Config {
     public static final String V1_PATH_OBSERVATIONS = "/v1/observations"
     public static final String V1_PATH_PATIENT_SETS = "/v1/patient_sets"
 
+    public static final String PATH_CONFIG = "/v2/admin/system/config"
+    public static final String AFTER_DATA_LOADING_UPDATE = "/v2/admin/system/after_data_loading_update"
+    public static final String UPDATE_STATUS = "/v2/admin/system/update_status"
+
     public static final String PATH_OBSERVATIONS = "/v2/observations"
     public static final String PATH_TABLE = "/v2/observations/table"
     public static final String PATH_CROSSTABLE = "/v2/observations/crosstable"
@@ -99,7 +103,6 @@ class Config {
     public static final String PATH_TREE_NODES_CLEAR_CACHE = "/v2/tree_nodes/clear_cache"
     public static final String PATH_STUDIES = "/v2/studies"
     public static final String PATH_PATIENT_SET = "/v2/patient_sets"
-    public static final String PATH_CONFIG = "/v2/admin/system/config"
     public static final String PATH_STORAGE = "/v2/storage"
     public static final String PATH_FILES = "/v2/files"
     public static final String PATH_ARVADOS_WORKFLOWS = "/v2/arvados/workflows"

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/SystemAdminSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/SystemAdminSpec.groovy
@@ -1,0 +1,57 @@
+/* (c) Copyright 2017, tranSMART Foundation, Inc. */
+
+package tests.rest.v2
+
+import base.RESTSpec
+import base.RestHelper
+import tests.rest.constraints
+
+import static base.ContentTypeFor.JSON
+import static config.Config.*
+
+class SystemAdminSpec extends RESTSpec {
+
+    def "after data loading call cache counts pers study and concept for admin user"() {
+        given:
+        def constraint = [constraint: [type: constraints.TrueConstraint]]
+        def user = ADMIN_USER
+
+        when:
+        afterDataLoadingCallSucceeds()
+        def countsPerStudyNConceptData = countsPerStudyAndConceptForTrueConstraint(user, constraint)
+
+        then: 'counts have been returned'
+        countsPerStudyNConceptData.countsPerStudy
+    }
+
+    private Map countsPerStudyAndConceptForTrueConstraint(user, constraint) {
+        def response = get([
+                path      : PATH_COUNTS_PER_STUDY_AND_CONCEPT,
+                acceptType: JSON,
+                user      : user,
+                query     : constraint,
+                statusCode: 200
+        ])
+        RestHelper.toObject(response, Map)
+    }
+
+    private boolean afterDataLoadingCallSucceeds() {
+        def updateResponse = get([
+                path      : AFTER_DATA_LOADING_UPDATE,
+                acceptType: JSON,
+                user      : ADMIN_USER,
+                statusCode: 200
+        ])
+        int times = 0
+        while (!['FAILED', 'COMPLETED'].contains(updateResponse.status) && ++times < 1000) {
+            updateResponse = get([
+                    path      : UPDATE_STATUS,
+                    acceptType: JSON,
+                    user      : ADMIN_USER,
+                    statusCode: 200
+            ])
+            Thread.sleep(500)
+        }
+        assert updateResponse.status == 'COMPLETED': "Update has failed: ${updateResponse.message}"
+    }
+}


### PR DESCRIPTION
it happened for admin users that had no permission specified.

It apeared that `rebuildCountsPerStudyAndConceptCache`
did double work. `rebuildCountsCacheForUser` pre-cached
counts already. Removing it seems like right solution.

Fixes https://jira.thehyve.nl/browse/TMT-435