### PR TITLE
Do not attempt study deletion when using pedigree mode. 

### DIFF
--- a/transmart-copy/src/main/groovy/org/transmartproject/copy/Copy.groovy
+++ b/transmart-copy/src/main/groovy/org/transmartproject/copy/Copy.groovy
@@ -199,7 +199,6 @@ class Copy implements AutoCloseable {
                 } else {
                     directory = '.'
                 }
-                copy.deleteStudy(directory, false)
                 int batchSize = cl.hasOption('batch-size') ?
                         cl.getOptionValue('batch-size') as int : Database.DEFAULT_BATCH_SIZE
                 int flushSize = cl.hasOption('flush-size') ?
@@ -220,6 +219,7 @@ class Copy implements AutoCloseable {
                     copy.uploadPedigree(directory, config)
                 }
                 if (!modes || 'study' in modes) {
+                    copy.deleteStudy(directory, false)
                     copy.uploadStudy(directory, config)
                 }
             }


### PR DESCRIPTION
This enables uploading patient relation data without having a study table. The patient relation tables are truncated and the information is not associated with any study.