### PR TITLE
Logging configuration update.

### DIFF
--- a/transmart-api-server/README.md
+++ b/transmart-api-server/README.md
@@ -109,6 +109,12 @@ Start `transmart-api-server` with this configuration file:
 java -jar -Dspring.config.location=transmart-api-server.config.yml transmart-api-server.war
 ```
 
+To use a custom logging configuration, provide the path of the `logback.groovy` file:
+```bash
+java -jar -Dlogging.config=/path/to/logback.groovy -Dspring.config.location=transmart-api-server.config.yml transmart-api-server.war
+```
+See [logback.groovy](grails-app/conf/logback.groovy) for the default logging configuration.
+
 
 [OpenID Connect]: https://openid.net/connect
 [Keycloak]: https://www.keycloak.org

--- a/transmart-api-server/grails-app/conf/logback.groovy
+++ b/transmart-api-server/grails-app/conf/logback.groovy
@@ -1,10 +1,19 @@
+/**
+ * Default logging configuration for the tranSMART API server.
+ * This configuration can be overridden by adding
+ * <code>-Dlogging.config=/path/to/logback.groovy</code> to
+ * the start script.
+ *
+ * See https://docs.grails.org/latest/guide/conf.html#externalLoggingConfiguration.
+ */
+
 import ch.qos.logback.contrib.jackson.JacksonJsonFormatter
 import grails.util.BuildSettings
 import grails.util.Environment
 import org.springframework.boot.logging.logback.ColorConverter
 import org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter
 import org.transmartproject.rest.logging.ApiAuditLogJsonLayout
-import org.transmartproject.rest.logging.ChildProcessAppender
+// import org.transmartproject.rest.logging.ChildProcessAppender
 
 import java.nio.charset.Charset
 
@@ -73,8 +82,7 @@ if (productionMode && logDirectory) {
 
 /**
  * Configuration for writing audit metrics.
- * This could be placed in the out-of-tree Config.groovy and will override the configuration below.
- * See https://logback.qos.ch/manual/appenders.html for details on configuration
+ * See https://logback.qos.ch/manual/appenders.html for details on configuration.
  */
 appender('fileAuditLogger', RollingFileAppender) {
     file = "${logDirectory}/audit.log"
@@ -101,10 +109,10 @@ appender('fileAuditLogger', RollingFileAppender) {
     }
 }
 
-appender('processAuditLogger', ChildProcessAppender) {
+// appender('processAuditLogger', ChildProcessAppender) {
     // specify the command as in the example below
     //    command = ['/usr/bin/your/command/here', 'arg1', 'arg2']
-}
+// }
 
 logger('org.transmartproject.db.log', TRACE, ['fileAuditLogger'], true)
-logger('org.transmartproject.db.log', TRACE, ['processAuditLogger'], true)
+// logger('org.transmartproject.db.log', TRACE, ['processAuditLogger'], true)

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/logging/ApiAuditLogJsonLayout.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/logging/ApiAuditLogJsonLayout.groovy
@@ -2,11 +2,13 @@ package org.transmartproject.rest.logging
 
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.contrib.json.JsonLayoutBase
+import groovy.transform.CompileStatic
 import org.transmartproject.core.binding.BindingHelper
 
 /**
  * Custom Json layout for writing audit metrics of API calls.
  */
+@CompileStatic
 class ApiAuditLogJsonLayout extends JsonLayoutBase<ILoggingEvent> {
 
     public static final String USERNAME_ATTR_NAME = "username"

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/logging/ChildProcessAppender.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/logging/ChildProcessAppender.groovy
@@ -27,7 +27,6 @@ import com.google.common.base.Charsets
 import groovy.transform.CompileStatic
 import groovy.transform.InheritConstructors
 import groovy.util.logging.Slf4j
-import org.grails.web.json.JSONObject
 
 import static java.lang.ProcessBuilder.Redirect.INHERIT
 


### PR DESCRIPTION
Previously, an error message would be written to stdout:
```
LOGBACK: No context given for ch.qos.logback.contrib.json.classic.JsonLayout@...
```