### PR TITLE
Fix worker pool for parallel tasks to one per system.

### DIFF
--- a/open-api/swagger.yaml
+++ b/open-api/swagger.yaml
@@ -2894,6 +2894,7 @@ paths:
     put:
       description: |
         This endpoint updates some configuration options at runtime.
+        The number of workers is not updated at runtime.
         Only for administrators.
       tags:
         - v2

--- a/transmart-api-server/src/main/groovy/org/transmartproject/api/server/server/SecurityConfig.groovy
+++ b/transmart-api-server/src/main/groovy/org/transmartproject/api/server/server/SecurityConfig.groovy
@@ -1,6 +1,5 @@
 package org.transmartproject.api.server.server
 
-import grails.util.Holders
 import groovy.util.logging.Slf4j
 import org.keycloak.adapters.KeycloakConfigResolver
 import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/support/ParallelPatientSetTaskService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/support/ParallelPatientSetTaskService.groovy
@@ -2,6 +2,7 @@ package org.transmartproject.db.support
 
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
+import jsr166y.ForkJoinPool
 import org.springframework.beans.factory.annotation.Autowired
 import org.transmartproject.core.config.SystemResource
 import org.transmartproject.core.exceptions.UnexpectedResultException
@@ -19,7 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Function
 
-import static groovyx.gpars.GParsPool.withPool
+import static groovyx.gpars.GParsPool.withExistingPool
 
 class ParallelPatientSetTaskService {
 
@@ -31,6 +32,9 @@ class ParallelPatientSetTaskService {
 
     @Autowired
     PatientSetResource patientSetResource
+
+    @Autowired
+    ForkJoinPool workerPool
 
 
     @Canonical
@@ -116,7 +120,7 @@ class ParallelPatientSetTaskService {
         final error = new AtomicBoolean(false)
         final numCompleted = new AtomicInteger(0)
         if (numTasks) {
-            withPool(workers) {
+            withExistingPool(workerPool) {
                 (1..numTasks).eachParallel { int i ->
                     try {
                         int offset = chunkSize * (i - 1)

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/support/SystemService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/support/SystemService.groovy
@@ -80,13 +80,11 @@ class SystemService implements SystemResource {
     @Autowired
     SessionFactory sessionFactory
 
-
     RuntimeConfig getRuntimeConfig() {
         return modelMapper.map(runtimeConfig, RuntimeConfigRepresentation.class)
     }
 
     RuntimeConfig updateRuntimeConfig(@Valid RuntimeConfig config) {
-        runtimeConfig.setNumberOfWorkers(config.numberOfWorkers)
         runtimeConfig.setPatientSetChunkSize(config.patientSetChunkSize)
         getRuntimeConfig()
     }

--- a/transmart-core-db/src/integration-test/groovy/org/transmartproject/db/multidimquery/ParallelAggregateDataServicePgSpec.groovy
+++ b/transmart-core-db/src/integration-test/groovy/org/transmartproject/db/multidimquery/ParallelAggregateDataServicePgSpec.groovy
@@ -3,6 +3,7 @@
 package org.transmartproject.db.multidimquery
 
 import grails.test.mixin.integration.Integration
+import grails.util.Holders
 import org.springframework.beans.factory.annotation.Autowired
 import org.transmartproject.core.config.RuntimeConfigRepresentation
 import org.transmartproject.core.config.SystemResource
@@ -47,6 +48,7 @@ class ParallelAggregateDataServicePgSpec extends Specification {
         Constraint patientSetConstraint = new PatientSetConstraint(patientSetId: patientSet.id)
 
         when: 'fetching all counts per study and concept for the patient set containing all patients with 4 workers'
+        Holders.config['org.transmartproject.system.numberOfWorkers'] = 4
         systemResource.updateRuntimeConfig(new RuntimeConfigRepresentation(4, 10))
         def countsPerStudyAndConcept = aggregateDataService.parallelCountsPerStudyAndConcept(patientSetConstraint, user)
         def counts = aggregateDataService.counts(new TrueConstraint(), user)

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/TransmartCoreGrailsPlugin.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/TransmartCoreGrailsPlugin.groovy
@@ -104,6 +104,8 @@ A runtime dependency for tranSMART that implements the Core API
                     expression: Component.canonicalName)
         }
 
+        context.'component-scan'('base-package': 'org.transmartproject.db.config')
+
         if (!config.org.transmartproject.i2b2.user_id) {
             config.org.transmartproject.i2b2.user_id = 'i2b2'
         }

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/config/RuntimeConfigImpl.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/config/RuntimeConfigImpl.groovy
@@ -21,10 +21,6 @@ class RuntimeConfigImpl implements RuntimeConfig {
         return numberOfWorkers.intValue()
     }
 
-    void setNumberOfWorkers(int numberOfWorkers) {
-        this.numberOfWorkers.set(numberOfWorkers)
-    }
-
     Integer getPatientSetChunkSize() {
         return patientSetChunkSize.intValue()
     }

--- a/transmart-core-db/src/main/groovy/org/transmartproject/db/config/SystemConfig.groovy
+++ b/transmart-core-db/src/main/groovy/org/transmartproject/db/config/SystemConfig.groovy
@@ -1,0 +1,23 @@
+package org.transmartproject.db.config
+
+import grails.util.Holders
+import groovy.util.logging.Slf4j
+import jsr166y.ForkJoinPool
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Slf4j
+@Configuration
+class SystemConfig {
+
+    @Bean
+    ForkJoinPool workerPool() {
+        def numberOfWorkers = Holders.config.getProperty(
+                'org.transmartproject.system.numberOfWorkers',
+                Integer.class,
+                Runtime.getRuntime().availableProcessors())
+        log.info "Create new worker pool for ${numberOfWorkers} workers"
+        new ForkJoinPool(numberOfWorkers)
+    }
+
+}


### PR DESCRIPTION
The system would spawn a new pool of threads for each request/operation (e.g., per export or per counts request) instead of having one pool for the entire system. This caused problems with the number of database connections.