### PR TITLE
Add minor documentation updates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -119,7 +119,7 @@ java -jar transmart-server-17.1-SNAPSHOT.war
 
 ### tranSMART Server:
 
-`Rserve` and `Solr` services can be run using `transmart-data`, see [Generate configuration files](#3-generate-configuration-files)
+`Rserve` and `Solr` services can be run using `transmart-data`, see [Setup configuration](#3-setup-configuration)
 to fetch it from a Nexus repository. 
 These instructions are using downloaded binaries, see the documentation of [transmart-data](../transmart-data) if you want 
 to use the sources. 

--- a/open-api/README.md
+++ b/open-api/README.md
@@ -1,5 +1,6 @@
 # Open API specification for the tranSMART platform
-[![Validation status](http://online.swagger.io/validator?url=https://raw.githubusercontent.com/thehyve/transmart-core/master/open-api/swagger.json)](http://online.swagger.io/validator/debug?url=https://raw.githubusercontent.com/thehyve/transmart-core/master/open-api/swagger.json)
+<!-- http://online.swagger.io does not support OpenApi 3 yet -->
+<!-- [![Validation status](http://online.swagger.io/validator?url=https://raw.githubusercontent.com/thehyve/transmart-core/master/open-api/swagger.json)](http://online.swagger.io/validator/debug?url=https://raw.githubusercontent.com/thehyve/transmart-core/master/open-api/swagger.json) -->
 
 ## Overview
 


### PR DESCRIPTION
The validation badge is hidden, because http://online.swagger.io does not support opeapi 3 validation