### PR TITLE
Remove new line character from string fields in spss export

### DIFF
--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/tabular/TabularResultSPSSSerializer.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/tabular/TabularResultSPSSSerializer.groovy
@@ -154,8 +154,14 @@ class TabularResultSPSSSerializer implements TabularResultSerializer {
         else if (value instanceof Date) {
             return formatDateRowValue((Date)value, metadata)
         } else {
-            return value.toString()
+            return toStringWithoutNewLineChar(value)
         }
+    }
+
+    private static String toStringWithoutNewLineChar(value) {
+        // in pspp the end of a line always separates fields, regardless of DELIMITERS
+        // so field with new line char, even surrounded by qualifier, breaks the sav file
+        value.toString().replaceAll("\r", "").replaceAll("\n", " ")
     }
 
     private String formatDateRowValue(Date value, VariableMetadata metadata) {


### PR DESCRIPTION
New line characters in strings fields, even surrounded by qualifier, always separate fields and invalid .sav files are produced.