### PR TITLE
Check access on patient set size

### DIFF
--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/querytool/QueryResultSummary.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/querytool/QueryResultSummary.groovy
@@ -16,7 +16,9 @@ interface QueryResultSummary {
     Long getId()
 
     /**
-     * The size of the set, or -1 if there was an error.
+     * The size of the set,
+     * or -1 if there was an error,
+     * or -2 if user does not have permission to the count.
      *
      * @return the size of the set
      */

--- a/transmart-rest-api/src/func-test/groovy/org/transmartproject/rest/v2/AccessPolicySpec.groovy
+++ b/transmart-rest-api/src/func-test/groovy/org/transmartproject/rest/v2/AccessPolicySpec.groovy
@@ -586,6 +586,31 @@ class AccessPolicySpec extends V2ResourceSpec {
 
     }
 
+    @Unroll
+    void 'test patient sets size (POST .../patient_sets) for constraint=#constraint and user with st1AccLvl=#s1AccLvl,  st2AccLvl=#s2AccLvl and threshold=#threshold.'() {
+
+        given:
+        def user = new MockUser('counts with threshold user', [study1: s1AccLvl, study2: s2AccLvl])
+        selectUser(user)
+        aggregateDataResourceImplService.patientCountThreshold = threshold
+
+        when:
+        def response = post("${contextPath}/patient_sets?name=test&reuse=false", constraint)
+
+        then:
+        checkResponseStatus(response, CREATED, user)
+        def result = toObject(response, Map)
+        result.setSize == size
+
+        where:
+        constraint         | threshold | s1AccLvl              | s2AccLvl              | size
+        trueConstraint     | 5         | SUMMARY               | SUMMARY               | 4L
+        trueConstraint     | 5         | COUNTS_WITH_THRESHOLD | COUNTS_WITH_THRESHOLD | -2L
+        trueConstraint     | 4         | COUNTS_WITH_THRESHOLD | COUNTS_WITH_THRESHOLD | 4L
+        trueConstraint     | 5         | SUMMARY               | COUNTS_WITH_THRESHOLD | -2L
+        study1OnlySubjects | 5         | SUMMARY               | COUNTS_WITH_THRESHOLD | 1L
+    }
+
     @Autowired
     AggregateDataResourceImplService aggregateDataResourceImplService
 


### PR DESCRIPTION
Users with count with threshold level of access
should not see original size of the patient set