### PR TITLE
Fix afternoon time for spss export

### DIFF
--- a/transmart-core-db/src/integration-test/groovy/org/transmartproject/db/multidimquery/QueryServicePgSpec.groovy
+++ b/transmart-core-db/src/integration-test/groovy/org/transmartproject/db/multidimquery/QueryServicePgSpec.groovy
@@ -44,6 +44,7 @@ import static spock.util.matcher.HamcrestSupport.that
 @Integration
 class QueryServicePgSpec extends Specification {
 
+    public static final String DATE_TIME_FORMAT = 'yyyy-MM-dd HH:mm:ss'
     @Autowired
     MultiDimensionalDataResource multiDimService
 
@@ -53,10 +54,10 @@ class QueryServicePgSpec extends Specification {
     @Autowired
     PatientSetService patientSetResource
 
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat('yyyy-MM-dd hh:mm:ss')
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat(DATE_TIME_FORMAT)
     private static final DateFormat UTC_DATE_FORMAT
     static {
-        UTC_DATE_FORMAT = new SimpleDateFormat('yyyy-MM-dd hh:mm:ss')
+        UTC_DATE_FORMAT = new SimpleDateFormat(DATE_TIME_FORMAT)
         UTC_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone('UTC'))
     }
 

--- a/transmart-core-db/src/integration-test/groovy/org/transmartproject/db/multidimquery/SurveyTableViewSpec.groovy
+++ b/transmart-core-db/src/integration-test/groovy/org/transmartproject/db/multidimquery/SurveyTableViewSpec.groovy
@@ -31,6 +31,8 @@ import static spock.util.matcher.HamcrestSupport.that
 @Integration
 class SurveyTableViewSpec extends Specification {
 
+    public static final String DATE_TIME_FORMAT = 'yyyy-MM-dd HH:mm:ss'
+
     @Autowired
     MultiDimensionalDataResource multiDimService
 
@@ -92,11 +94,11 @@ class SurveyTableViewSpec extends Specification {
         secondSubjRow
         secondSubjRow[columns[0]] == '2'
         secondSubjRow[columns[1]] == Date.parse('yyyy-MM-dd', '1986-10-22', UTC)
-        secondSubjRow[columns[2]] == Date.parse('yyyy-MM-dd hh:mm:ss', '2010-12-16 20:23:15')
-        secondSubjRow[columns[3]] == Date.parse('yyyy-MM-dd hh:mm:ss', '2001-09-01 05:30:05', UTC)
-        secondSubjRow[columns[4]] == Date.parse('yyyy-MM-dd hh:mm:ss', '2010-12-16 20:23:15')
+        secondSubjRow[columns[2]] == Date.parse(DATE_TIME_FORMAT, '2010-12-16 20:23:15')
+        secondSubjRow[columns[3]] == Date.parse(DATE_TIME_FORMAT, '2001-09-01 05:30:05', UTC)
+        secondSubjRow[columns[4]] == Date.parse(DATE_TIME_FORMAT, '2010-12-16 20:23:15')
         that secondSubjRow[columns[5]] as String, containsString('Dostoyevsky')
-        secondSubjRow[columns[6]] == Date.parse('yyyy-MM-dd hh:mm:ss', '2016-03-21 10:36:01')
+        secondSubjRow[columns[6]] == Date.parse(DATE_TIME_FORMAT, '2016-03-21 10:36:01')
         secondSubjRow[columns[7]] == -2
         secondSubjRow[columns[8]] == null
         secondSubjRow[columns[13]] == '3'
@@ -104,11 +106,11 @@ class SurveyTableViewSpec extends Specification {
         def firstSubjRow = rows.find { row ->  row[columns[0]] == '1' }
         firstSubjRow[columns[0]] == '1'
         firstSubjRow[columns[1]] == Date.parse('yyyy-MM-dd', '1980-08-12', UTC)
-        firstSubjRow[columns[2]] == Date.parse('yyyy-MM-dd hh:mm:ss', '2015-11-14 19:05:00')
+        firstSubjRow[columns[2]] == Date.parse(DATE_TIME_FORMAT, '2015-11-14 19:05:00')
         firstSubjRow[columns[3]] == null
         firstSubjRow[columns[4]] == null
         that firstSubjRow[columns[5]] as String, containsString('Hofstadter')
-        firstSubjRow[columns[6]] == Date.parse('yyyy-MM-dd hh:mm:ss', '2016-03-21 10:36:01')
+        firstSubjRow[columns[6]] == Date.parse(DATE_TIME_FORMAT, '2016-03-21 10:36:01')
         firstSubjRow[columns[7]] == 2
         firstSubjRow[columns[8]] == null
         firstSubjRow[columns[13]] == 10
@@ -171,9 +173,9 @@ class SurveyTableViewSpec extends Specification {
         firstSubjRow
         firstSubjRow[columns[0]] == '1'
         firstSubjRow[columns[1]] == 'Description about subject 1'
-        firstSubjRow[columns[2]] == Date.parse('yyyy-MM-dd hh:mm:ss', '2016-03-21 10:36:01')
+        firstSubjRow[columns[2]] == Date.parse(DATE_TIME_FORMAT, '2016-03-21 10:36:01')
         firstSubjRow[columns[3]] == -1
-        firstSubjRow[columns[4]] == Date.parse('yyyy-MM-dd hh:mm:ss', '2005-05-24 13:40:00')
+        firstSubjRow[columns[4]] == Date.parse(DATE_TIME_FORMAT, '2005-05-24 13:40:00')
 
         def secondSubjRow = rows.find { row ->  row[columns[0]] == '2' }
         secondSubjRow
@@ -181,7 +183,7 @@ class SurveyTableViewSpec extends Specification {
         secondSubjRow[columns[1]] == 'No description'
         secondSubjRow[columns[2]] == null
         secondSubjRow[columns[3]] <=> 169 == 0
-        secondSubjRow[columns[4]] == Date.parse('yyyy-MM-dd hh:mm:ss', '2004-08-27 10:45:32')
+        secondSubjRow[columns[4]] == Date.parse(DATE_TIME_FORMAT, '2004-08-27 10:45:32')
 
         when: 'do not include MeasurementDateColumn'
         includeMeasurementDateColumns = false

--- a/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/tabular/TabularResultSPSSSerializer.groovy
+++ b/transmart-rest-api/src/main/groovy/org/transmartproject/rest/serialization/tabular/TabularResultSPSSSerializer.groovy
@@ -28,7 +28,7 @@ class TabularResultSPSSSerializer implements TabularResultSerializer {
 
     final static char COLUMN_SEPARATOR = '\t' as char
     private final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("dd-MM-yyyy")
-    private final SimpleDateFormat DATETIME_FORMAT = new SimpleDateFormat("dd-MM-yyyy hh:mm:ss")
+    private final SimpleDateFormat DATETIME_FORMAT = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss")
 
     private final static toSpssLabel(String label) {
         label?.replaceAll(/[^a-zA-Z0-9_.]/, '_')

--- a/transmart-rest-api/src/test/groovy/org/transmartproject/rest/serialization/tabular/TabularResultSPSSSerializerSpec.groovy
+++ b/transmart-rest-api/src/test/groovy/org/transmartproject/rest/serialization/tabular/TabularResultSPSSSerializerSpec.groovy
@@ -40,6 +40,7 @@ import static org.transmartproject.rest.serialization.tabular.TabularResultSPSSS
 
 class TabularResultSPSSSerializerSpec extends Specification {
 
+    public static final String DATE_TIME_FORMAT = 'yyyy-MM-dd HH:mm:ss'
     private static interface MetadataAwareValueFetchingDataColumn extends MetadataAwareDataColumn, ValueFetchingDataColumn {}
 
     private final UTC = TimeZone.getTimeZone('UTC')
@@ -348,13 +349,13 @@ class TabularResultSPSSSerializerSpec extends Specification {
         def columns = ImmutableList.copyOf([column1, column2, column3] as List<DataColumn>)
         table.indicesList >> [column1, column2, column3]
         def row1 = Mock(HypercubeDataRow)
-        row1.getAt(column1) >> Date.parse('yyyy-MM-dd hh:mm:ss', '2001-09-01 09:45:18', UTC)
-        row1.getAt(column2) >> Date.parse('yyyy-MM-dd hh:mm:ss', '2009-12-01 09:45:18', UTC)
-        row1.getAt(column3) >> Date.parse('yyyy-MM-dd hh:mm:ss', '2001-09-01 09:45:18', UTC)
+        row1.getAt(column1) >> Date.parse(DATE_TIME_FORMAT, '2001-09-01 09:45:18', UTC)
+        row1.getAt(column2) >> Date.parse(DATE_TIME_FORMAT, '2009-12-01 09:45:18', UTC)
+        row1.getAt(column3) >> Date.parse(DATE_TIME_FORMAT, '2001-09-01 09:45:18', UTC)
         def row2 = Mock(HypercubeDataRow)
         row2.getAt(column1) >> Date.parse('dd-MM-yyyy', '28-11-2005', UTC)
-        row2.getAt(column2) >> Date.parse('dd-MM-yyyy hh:mm:ss', '12-02-1998 00:45:33', CEST)
-        row2.getAt(column3) >> Date.parse('dd-MM-yyyy hh:mm:ss', '12-02-1998 18:30:05', CEST)
+        row2.getAt(column2) >> Date.parse(DATE_TIME_FORMAT, '1998-02-12 00:45:33', CEST)
+        row2.getAt(column3) >> Date.parse(DATE_TIME_FORMAT, '1998-02-12 18:30:05', CEST)
         List<DataRow> rows = [row1, row2]
         table.rows >> rows.iterator()
 
@@ -373,9 +374,9 @@ class TabularResultSPSSSerializerSpec extends Specification {
         lines[0][0] == "01-09-2001 09:45:18"
         lines[0][1] == "01-12-2009"
         lines[0][2] == "01-09-2001 09:45:18"
-        lines[1][0] == "28-11-2005 12:00:00"
+        lines[1][0] == "28-11-2005 00:00:00"
         lines[1][1] == "12-02-1998"
-        lines[1][2] == "12-02-1998 06:30:05"
+        lines[1][2] == "12-02-1998 18:30:05"
 
     }
 


### PR DESCRIPTION
It used 1-12h format without am/pm specification.
Use 0-23h datetime format for intermediate tsv export instead.

Java date format:
hh - 1-12
HH - 0-23


See TMT-648 for more details.