### PR TITLE
Stop sharing security context between http sessions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - DIR=transmart-rest-api; TEST=check
     - DIR=transmart-core-db; INSTALL=":transmart-data:createVars :transmart-data:setupPostgresTest"; TEST=check
     - DIR=transmart-api-server; TEST=check
-    - DIR=transmart-batch; INSTALL=":transmart-data:createVars :transmart-data:setupPostgres travisPreparePostgres"; PREPARE=shadowJar; TEST="test functionalTest"
+    - DIR=transmart-batch; INSTALL=":transmart-data:createVars :transmart-data:setupPostgres travisPreparePostgres"; PREPARE=shadowJar; TEST=check
     - DIR=transmart-solr-indexing; INSTALL=":transmart-data:createVars :transmart-data:setupPostgresTest :transmart-batch:travisProperties :transmart-batch:loadPublicTestStudy"; TEST="check"; START_SOLR=true
     - DIR=transmart-copy; INSTALL=":transmart-data:createVars :transmart-data:setupPostgresTest"; PREPARE=shadowJar; TEST=check
     - DIR=.; TEST="publishToMavenLocal"

--- a/transmart-api-server/src/main/groovy/org/transmartproject/api/server/server/SecurityConfig.groovy
+++ b/transmart-api-server/src/main/groovy/org/transmartproject/api/server/server/SecurityConfig.groovy
@@ -13,8 +13,8 @@ import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.core.session.SessionRegistryImpl
-import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy
 import org.springframework.web.client.RestOperations
 import org.springframework.web.client.RestTemplate
@@ -33,7 +33,7 @@ class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
 
     @Override
     protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
-        new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl())
+        new NullAuthenticatedSessionStrategy()
     }
 
     /**
@@ -69,7 +69,11 @@ class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         super.configure(http)
-        http.authorizeRequests()
+        http.sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .sessionAuthenticationStrategy(sessionAuthenticationStrategy())
+                .and()
+                .authorizeRequests()
                 .antMatchers("/v1/*").denyAll()
                 .antMatchers("/v2/admin/**").hasRole('ADMIN')
                 .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/transmart-batch/build.gradle
+++ b/transmart-batch/build.gradle
@@ -214,3 +214,12 @@ publishing {
         }
     }
 }
+
+//FIXME A fix should apear here https://discuss.gradle.org/t/sudden-issue-with-gradle-3-5-1-and-codenarc/30064
+configurations.codenarc {
+    resolutionStrategy.eachDependency { DependencyResolveDetails d ->
+        if (d.requested.group == 'org.codehaus.groovy') {
+            d.useVersion '2.1.8'
+        }
+    }
+}

--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/clinical/ontology/InsertOntologyTreeTasklet.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/clinical/ontology/InsertOntologyTreeTasklet.groovy
@@ -45,7 +45,7 @@ class InsertOntologyTreeTasklet implements Tasklet {
             def result = entryMap[code]
             if (!result) {
                 log.error "Perhaps a cycle in the ontology mapping?"
-                throw new RuntimeException("Unexpected state: node visited before, but no result available.")
+                throw new IllegalStateException("Unexpected state: node visited before, but no result available.")
             }
             return result
         }

--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/concept/InsertConceptsService.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/concept/InsertConceptsService.groovy
@@ -256,9 +256,8 @@ class InsertConceptsService {
                 return 'FAS'
             } else if (concept.type == ConceptType.CATEGORICAL) {
                 return 'FAC'
-            } else {
-                return 'FA '
             }
+            return 'FA '
         }
     }
 

--- a/transmart-batch/src/main/groovy/org/transmartproject/batch/ontologymapping/WriteOntologyMappingTasklet.groovy
+++ b/transmart-batch/src/main/groovy/org/transmartproject/batch/ontologymapping/WriteOntologyMappingTasklet.groovy
@@ -37,9 +37,10 @@ class WriteOntologyMappingTasklet implements Tasklet {
         def nodes = ontologyMappingHolder.nodes.values()
         log.info "Writing ${nodes.size()} ontology entries."
 
-        if (!resource.file.getParentFile().exists()) {
-            log.info "Directory ${resource.file.getParentFile().path} does not exist. Creating..."
-            resource.file.getParentFile().mkdirs()
+        def parentFile = resource.file.parentFile
+        if (!parentFile.exists()) {
+            log.info "Directory ${parentFile.path} does not exist. Creating..."
+            parentFile.mkdirs()
         }
         OntologyMapTsvWriter.write(resource.outputStream, nodes)
         contribution.incrementWriteCount(ontologyMappingHolder.nodes.size())

--- a/transmart-copy/build.gradle
+++ b/transmart-copy/build.gradle
@@ -59,4 +59,13 @@ codenarc {
     reportFormat = 'html'
 }
 
+//FIXME A fix should apear here https://discuss.gradle.org/t/sudden-issue-with-gradle-3-5-1-and-codenarc/30064
+configurations.codenarc {
+    resolutionStrategy.eachDependency { DependencyResolveDetails d ->
+        if (d.requested.group == 'org.codehaus.groovy') {
+            d.useVersion '2.1.8'
+        }
+    }
+}
+
 test.testLogging.exceptionFormat = 'full'


### PR DESCRIPTION
Fixes TMT-658
When the security context is shared the authentification field gets mutated by multiple concurrent requests causing all sort of issues. Each request starts with setting authentification field with unauthenticated bean first and only after analyzing the token with authenticated.

The PR makes each request to use own security context instance.

The http session instance still could be shared between http requests when jsessionid is supplied in the cookie header.
TMT-664 is a ticket to asses how harmless it that.