### PR TITLE
Make ts copy support sparse ids

### DIFF
--- a/transmart-copy/src/main/groovy/org/transmartproject/copy/table/Dimensions.groovy
+++ b/transmart-copy/src/main/groovy/org/transmartproject/copy/table/Dimensions.groovy
@@ -30,7 +30,7 @@ class Dimensions {
     final LinkedHashMap<String, Class> columns
 
     final Map<String, Long> dimensionNameToId = [:]
-    final List<Long> indexToDimensionId = []
+    final Map<Long, Long> indexToDimensionId = [:]
     final Set<String> modifierDimensionCodes = []
 
     Dimensions(Database database) {
@@ -84,10 +84,6 @@ class Dimensions {
                 try {
                     def dimensionData = Util.asMap(header, data)
                     def dimensionIndex = dimensionData['id'] as long
-                    if (i != dimensionIndex + 1) {
-                        throw new IllegalStateException(
-                                "The dimension descriptions are not in order. (Found ${dimensionIndex} on line ${i}.)")
-                    }
                     def dimensionName = dimensionData['name'] as String
                     def dimensionId = dimensionNameToId[dimensionName]
                     if (dimensionId) {
@@ -105,7 +101,7 @@ class Dimensions {
                         dimensionId = database.insertEntry(TABLE, header, 'id', dimensionData)
                         log.debug "Dimension description inserted [id: ${dimensionId}]."
                     }
-                    indexToDimensionId.add(dimensionId)
+                    indexToDimensionId.put(dimensionIndex, dimensionId)
                     log.debug "Registered dimension at index ${dimensionIndex}: ${dimensionName} [${dimensionId}]."
                 } catch(Throwable e) {
                     log.error "Error on line ${i} of ${TABLE.fileName}: ${e.message}."

--- a/transmart-copy/src/main/groovy/org/transmartproject/copy/table/Observations.groovy
+++ b/transmart-copy/src/main/groovy/org/transmartproject/copy/table/Observations.groovy
@@ -71,23 +71,15 @@ class Observations {
 
     void transformRow(final Map<String, Object> row, final int baseInstanceNum) {
         // replace patient index with patient num
-        int patientIndex = ((BigDecimal) row.get('patient_num')).intValueExact()
-        if (patientIndex >= patients.indexToPatientNum.size()) {
-            throw new IllegalStateException(
-                    "Patient index higher than the number of patients (${patients.indexToPatientNum.size()})")
-        }
+        Long patientIndex = ((BigDecimal) row.get('patient_num')).longValueExact()
         row.put('patient_num', patients.indexToPatientNum[patientIndex])
-        int trialVisitIndex = ((BigDecimal) row.get('trial_visit_num')).intValueExact()
-        if (trialVisitIndex >= studies.indexToTrialVisitNum.size()) {
-            throw new IllegalStateException(
-                    "Trial visit index higher than the number of trial visits (${studies.indexToTrialVisitNum.size()})")
-        }
+        Long trialVisitIndex = ((BigDecimal) row.get('trial_visit_num')).longValueExact()
         row.put('trial_visit_num', studies.indexToTrialVisitNum[trialVisitIndex])
         String conceptCode = (String) row.get('concept_cd')
         if (!(conceptCode in concepts.conceptCodes)) {
             throw new IllegalStateException("Unknown concept code: ${conceptCode}")
         }
-        int instanceIndex = ((BigDecimal) row.get('instance_num')).intValueExact()
+        Long instanceIndex = ((BigDecimal) row.get('instance_num')).longValueExact()
         row.put('instance_num', baseInstanceNum + instanceIndex)
         if (!row.get('start_date')) {
             row.put('start_date', EMPTY_DATE)


### PR DESCRIPTION
To be able to load current test_data.

This PR removes the requirement to the source data to specify ids in accordance with row number (row - 2 when we count with the header).

SIDE CHANGES:

 - Use `long` instead of `integer` type to represent source data ids (aka index)

TODO:
 - add a check that neither source id (aka index), nor result db id are not null. Add this check on lookup and before setting a new value.
 -  add check for duplicates. Smth like:
```
if (indexToPatientNum.containsKey(patientIndex)) {
	throw new IllegalStateException("Patient with patient_num=${patientIndex} has bee already inserted")
}
``` 