### PR TITLE
Deprecate extracted user query related functionality in transmart-core

### DIFF
--- a/open-api/swagger.yaml
+++ b/open-api/swagger.yaml
@@ -272,7 +272,7 @@ info:
     }
 
     ```
-    
+
     Example that includes modifier-based dimensions: Select all observations for patients who have certain tumor type and it's biomaterial with certain type.
 
     ```json
@@ -2673,10 +2673,29 @@ paths:
                     items:
                       type: string
 
+  /v2/pedigree/relation_types:
+    get:
+      description: |
+        Gets the list of the relation types.
+      tags:
+        - v2
+      responses:
+        '200':
+          description: |
+            returns the list of the relation types.
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RelationType'
+
   /v2/queries:
     get:
       description: |
         Gets a list of all queries for current user.
+        Deprecated. User queries related functionality has been moved to a gb-backend application
+      deprecated: true
       tags:
         - v2
       responses:
@@ -2695,6 +2714,8 @@ paths:
     post:
       description: |
         Adds a new user query with the properties provided in the body.
+        Deprecated. User queries related functionality has been moved to a gb-backend application.
+      deprecated: true
       tags:
         - v2
       responses:
@@ -2730,7 +2751,9 @@ paths:
   '/v2/queries/{id}':
     get:
       description: |
-        Gets the user query with the given `id`
+        Gets the user query with the given `id`.
+        Deprecated. User queries related functionality has been moved to a gb-backend application.
+      deprecated: true
       tags:
         - v2
       parameters:
@@ -2750,6 +2773,8 @@ paths:
     put:
       description: |
         Updates the user query with given id with the values in the body.
+        Deprecated. User queries related functionality has been moved to a gb-backend application.
+      deprecated: true
       tags:
         - v2
       parameters:
@@ -2781,6 +2806,8 @@ paths:
     delete:
       description: |
         Deletes the user query with the given id.
+        Deprecated. User queries related functionality has been moved to a gb-backend application.
+      deprecated: true
       tags:
         - v2
       parameters:
@@ -2793,28 +2820,13 @@ paths:
         '204':
           description: returns null
 
-  /v2/pedigree/relation_types:
-    get:
-      description: |
-        Gets the list of the relation types.
-      tags:
-        - v2
-      responses:
-        '200':
-          description: |
-            returns the list of the relation types.
-          content:
-            '*/*':
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RelationType'
-
   '/v2/queries/{queryId}/sets':
     get:
       description: |
         Gets a list of query result change entries by query id.
         History of data changes for specific query.
+        Deprecated. User queries related functionality has been moved to a gb-backend application.
+      deprecated: true
       tags:
         - v2
       parameters:
@@ -2988,12 +3000,16 @@ paths:
     get:
       description: >
         Triggers sending of emails to users that subscribed for updates
+
         regarding queries they have created.
 
         Only for administrators.
 
         This requires transmart-notifications plugin and
         `/v2/admin/notifications/notify` endpoint to be enabled.
+
+        Deprecated. User queries related functionality has been moved to a gb-backend application.
+      deprecated: true
       tags:
         - v2
         - admin

--- a/transmart-api-server/build.gradle
+++ b/transmart-api-server/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     //Custom dependencies
     compile project(':transmart-rest-api')
+    //Deprecated plugin - user queries related functionality has been moved to a gb-backend application
     compile project(':transmart-notifications')
 
     compile "org.keycloak:keycloak-spring-boot-starter:4.0.0.Final"

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/ChangeFlag.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/ChangeFlag.groovy
@@ -4,8 +4,10 @@ import groovy.transform.CompileStatic
 
 /**
  * The update data change type
+ * @deprecated user queries related functionality has been moved to a gb-backend application
  */
 @CompileStatic
+@Deprecated
 enum ChangeFlag {
 
     ADDED,

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/SubscriptionFrequency.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/SubscriptionFrequency.groovy
@@ -5,8 +5,10 @@ import groovy.transform.CompileStatic
 
 /**
  * The frequency of emails for user query subscription
+ * @deprecated user queries related functionality has been moved to a gb-backend application
  */
 @CompileStatic
+@Deprecated
 enum SubscriptionFrequency {
 
     DAILY,

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuery.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuery.groovy
@@ -2,7 +2,9 @@ package org.transmartproject.core.userquery
 
 /**
  *  Stores patients and observations parts of queries
+ *  @deprecated user queries related functionality has been moved to a gb-backend application
  */
+@Deprecated
 interface UserQuery {
     /**
      * Internal system identifier of the query.

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQueryRepresentation.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQueryRepresentation.groovy
@@ -12,6 +12,7 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING
 
 @Canonical
 @CompileStatic
+@Deprecated
 class UserQueryRepresentation {
 
     Long id

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQueryResource.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQueryResource.groovy
@@ -7,7 +7,9 @@ import org.transmartproject.core.users.User
 
 /**
  * User queries resource
+ * @deprecated user queries related functionality has been moved to a gb-backend application
  */
+@Deprecated
 interface UserQueryResource {
 
     /**

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuerySet.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuerySet.groovy
@@ -2,7 +2,9 @@ package org.transmartproject.core.userquery
 
 /**
  *  Stores query result changes
+ *  @deprecated user queries related functionality has been moved to a gb-backend application
  */
+@Deprecated
 interface UserQuerySet {
 
     /**

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuerySetChangesRepresentation.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuerySetChangesRepresentation.groovy
@@ -6,9 +6,11 @@ import groovy.transform.CompileStatic
 /**
  * Representation of changes made in the query_set - added and removed objects,
  * in comparison to the previous query_set related to the same query
+ * @deprecated user queries related functionality has been moved to a gb-backend application
  */
 @Canonical
 @CompileStatic
+@Deprecated
 class UserQuerySetChangesRepresentation {
     Long id
     SetType setType

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuerySetDiff.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuerySetDiff.groovy
@@ -2,7 +2,9 @@ package org.transmartproject.core.userquery
 
 /**
  *  Stores query result change entries
+ *  @deprecated user queries related functionality has been moved to a gb-backend application
  */
+@Deprecated
 interface UserQuerySetDiff {
     /**
      * Internal system identifier of the querySetInstance.

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuerySetInstance.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuerySetInstance.groovy
@@ -2,7 +2,9 @@ package org.transmartproject.core.userquery
 
 /**
  *  Stores query result change entries
+ *  @deprecated user queries related functionality has been moved to a gb-backend application
  */
+@Deprecated
 interface UserQuerySetInstance {
     /**
      * Internal system identifier of the querySetInstance.

--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuerySetResource.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/userquery/UserQuerySetResource.groovy
@@ -6,7 +6,9 @@ import org.transmartproject.core.users.User
 
 /**
  * User query result changes resource
+ * @deprecated user queries related functionality has been moved to a gb-backend application
  */
+@Deprecated
 interface UserQuerySetResource {
 
     /**

--- a/transmart-core-db-tests/src/integration-test/groovy/org/transmartproject/db/userqueries/UserQuerySetServiceSpec.groovy
+++ b/transmart-core-db-tests/src/integration-test/groovy/org/transmartproject/db/userqueries/UserQuerySetServiceSpec.groovy
@@ -23,6 +23,7 @@ import org.transmartproject.db.user.MockUsersResource
 import spock.lang.Specification
 
 @Integration
+@Deprecated
 class UserQuerySetServiceSpec extends Specification {
 
     @Autowired

--- a/transmart-core-db/grails-app/domain/org/transmartproject/db/querytool/Query.groovy
+++ b/transmart-core-db/grails-app/domain/org/transmartproject/db/querytool/Query.groovy
@@ -23,6 +23,7 @@ import org.springframework.validation.Errors
 import org.transmartproject.core.userquery.SubscriptionFrequency
 import org.transmartproject.core.userquery.UserQuery
 
+@Deprecated
 class Query implements UserQuery {
 
     String name

--- a/transmart-core-db/grails-app/domain/org/transmartproject/db/querytool/QuerySet.groovy
+++ b/transmart-core-db/grails-app/domain/org/transmartproject/db/querytool/QuerySet.groovy
@@ -22,6 +22,7 @@ package org.transmartproject.db.querytool
 import org.transmartproject.core.userquery.SetType
 import org.transmartproject.core.userquery.UserQuerySet
 
+@Deprecated
 class QuerySet implements UserQuerySet {
 
     Long id

--- a/transmart-core-db/grails-app/domain/org/transmartproject/db/querytool/QuerySetDiff.groovy
+++ b/transmart-core-db/grails-app/domain/org/transmartproject/db/querytool/QuerySetDiff.groovy
@@ -22,7 +22,7 @@ package org.transmartproject.db.querytool
 import org.transmartproject.core.userquery.ChangeFlag
 import org.transmartproject.core.userquery.UserQuerySetDiff
 
-
+@Deprecated
 class QuerySetDiff implements UserQuerySetDiff {
 
     Long id

--- a/transmart-core-db/grails-app/domain/org/transmartproject/db/querytool/QuerySetInstance.groovy
+++ b/transmart-core-db/grails-app/domain/org/transmartproject/db/querytool/QuerySetInstance.groovy
@@ -21,6 +21,7 @@ package org.transmartproject.db.querytool
 
 import org.transmartproject.core.userquery.UserQuerySetInstance
 
+@Deprecated
 class QuerySetInstance implements UserQuerySetInstance {
 
     Long id

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/userqueries/UserQueryService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/userqueries/UserQueryService.groovy
@@ -28,6 +28,7 @@ import java.util.stream.Collectors
 
 @Transactional
 @CompileStatic
+@Deprecated
 class UserQueryService implements UserQueryResource {
 
     @Autowired

--- a/transmart-core-db/grails-app/services/org/transmartproject/db/userqueries/UserQuerySetService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/userqueries/UserQuerySetService.groovy
@@ -29,6 +29,7 @@ import static org.transmartproject.db.multidimquery.DimensionImpl.PATIENT
 
 @Transactional
 @CompileStatic
+@Deprecated
 class UserQuerySetService implements UserQuerySetResource {
 
     @Autowired

--- a/transmart-data/ddl/oracle/biomart_user/query.sql
+++ b/transmart-data/ddl/oracle/biomart_user/query.sql
@@ -1,5 +1,6 @@
 --
 -- Type: TABLE; Owner: BIOMART_USER; Name: QUERY
+-- DEPRECATED! user queries related functionality has been moved to a gb-backend application
 --
 CREATE TABLE "BIOMART_USER"."QUERY"
 (
@@ -54,7 +55,7 @@ ALTER TRIGGER "BIOMART_USER"."TRG_QUERY_ID" ENABLE;
 --
 -- Table documentation
 --
-COMMENT ON TABLE biomart_user.query IS 'Storage for patients and observations queries to support front end functionality.';
+COMMENT ON TABLE biomart_user.query IS 'Storage for patients and observations queries to support front end functionality. DEPRECATED! This table has been moved to a gb-backend application database';
 
 COMMENT ON COLUMN biomart_user.query.name IS 'The query name.';
 COMMENT ON COLUMN biomart_user.query.username IS 'The username of the user that created the query.';

--- a/transmart-data/ddl/oracle/biomart_user/query_set.sql
+++ b/transmart-data/ddl/oracle/biomart_user/query_set.sql
@@ -1,5 +1,6 @@
 --
 -- Type: TABLE; Owner: BIOMART_USER; Name: QUERY_SET
+-- DEPRECATED! user queries related functionality has been moved to a gb-backend application
 --
 CREATE TABLE "BIOMART_USER"."QUERY_SET"
 (
@@ -35,7 +36,7 @@ ALTER TRIGGER "BIOMART_USER"."TRG_QUERY_SET_ID" ENABLE;
 --
 -- Table documentation
 --
-COMMENT ON TABLE biomart_user.query_set IS 'Table stores information about data sets for user queries.';
+COMMENT ON TABLE biomart_user.query_set IS 'Table stores information about data sets for user queries. DEPRECATED! This table has been moved to a gb-backend application database';
 
 COMMENT ON COLUMN biomart_user.query_set.query_id IS 'Foreign key to id in a query table.';
 COMMENT ON COLUMN biomart_user.query_set.set_size IS 'The size of the set';

--- a/transmart-data/ddl/oracle/biomart_user/query_set_diff.sql
+++ b/transmart-data/ddl/oracle/biomart_user/query_set_diff.sql
@@ -1,5 +1,6 @@
 --
 -- Type: TABLE; Owner: BIOMART_USER; Name: QUERY_SET_DIFF
+-- DEPRECATED! user queries related functionality has been moved to a gb-backend application
 --
 CREATE TABLE "BIOMART_USER"."QUERY_SET_DIFF"
 (
@@ -34,7 +35,7 @@ ALTER TRIGGER "BIOMART_USER"."TRG_QUERY_SET_DIFF_ID" ENABLE;
 --
 -- Table documentation
 --
-COMMENT ON TABLE biomart_user.query_set_diff IS 'Table stores information about specific objects, deleted or added to the subscribed user query related set.';
+COMMENT ON TABLE biomart_user.query_set_diff IS 'Table stores information about specific objects, deleted or added to the subscribed user query related set. DEPRECATED! This table has been moved to a gb-backend application database.';
 
 COMMENT ON COLUMN biomart_user.query_set_diff.query_set_id IS 'Foreign key to id in query_set table.';
 COMMENT ON COLUMN biomart_user.query_set_diff.object_id IS 'The id of the object from the set that was updated, e.g. id of an i2b2demodata.patient_dimension instance.';

--- a/transmart-data/ddl/oracle/biomart_user/query_set_instance.sql
+++ b/transmart-data/ddl/oracle/biomart_user/query_set_instance.sql
@@ -1,5 +1,6 @@
 --
 -- Type: TABLE; Owner: BIOMART_USER; Name: QUERY_SET_INSTANCE
+-- DEPRECATED! user queries related functionality has been moved to a gb-backend application
 --
 CREATE TABLE "BIOMART_USER"."QUERY_SET_INSTANCE"
 (
@@ -33,7 +34,7 @@ ALTER TRIGGER "BIOMART_USER"."TRG_QUERY_SET_INSTANCE_ID" ENABLE;
 --
 -- Table documentation
 --
-COMMENT ON TABLE biomart_user.query_set_instance IS 'Table stores information about specific instances of the query set';
+COMMENT ON TABLE biomart_user.query_set_instance IS 'Table stores information about specific instances of the query set. DEPRECATED! This table has been moved to a gb-backend application database.';
 
 COMMENT ON COLUMN biomart_user.query_set_instance.query_set_id IS 'Foreign key to id in query_set table.';
 COMMENT ON COLUMN biomart_user.query_set_instance.object_id IS 'The id of the object that is being represented by the set instance, e.g. id of an i2b2demodata.patient_dimension instance.';

--- a/transmart-data/ddl/postgres/biomart_user/query.sql
+++ b/transmart-data/ddl/postgres/biomart_user/query.sql
@@ -1,5 +1,6 @@
 --
 -- Name: query; Type: TABLE; Schema: biomart_user; Owner: -
+-- DEPRECATED! user queries related functionality has been moved to a gb-backend application
 --
 CREATE TABLE biomart_user.query (
     id SERIAL PRIMARY KEY,
@@ -29,7 +30,7 @@ CREATE INDEX query_username_subscribed ON biomart_user.query USING btree (userna
 --
 -- Table documentation
 --
-COMMENT ON TABLE biomart_user.query IS 'Storage for patients and observations queries to support front end functionality.';
+COMMENT ON TABLE biomart_user.query IS 'Storage for patients and observations queries to support front end functionality. DEPRECATED! This table has been moved to a gb-backend application database.';
 
 COMMENT ON COLUMN biomart_user.query.name IS 'The query name.';
 COMMENT ON COLUMN biomart_user.query.username IS 'The username of the user that created the query.';

--- a/transmart-data/ddl/postgres/biomart_user/query_set.sql
+++ b/transmart-data/ddl/postgres/biomart_user/query_set.sql
@@ -1,5 +1,6 @@
 --
 -- Name: query_set; Type: TABLE; Schema: biomart_user; Owner: -
+-- DEPRECATED! user queries related functionality has been moved to a gb-backend application
 --
 CREATE TABLE biomart_user.query_set (
     id SERIAL PRIMARY KEY,
@@ -18,7 +19,7 @@ ALTER TABLE ONLY biomart_user.query_set
 --
 -- Table documentation
 --
-COMMENT ON TABLE biomart_user.query_set IS 'Table stores information about data sets for user queries.';
+COMMENT ON TABLE biomart_user.query_set IS 'Table stores information about data sets for user queries. DEPRECATED! This table has been moved to a gb-backend application database.';
 
 COMMENT ON COLUMN biomart_user.query_set.query_id IS 'Foreign key to id in a query table.';
 COMMENT ON COLUMN biomart_user.query_set.set_size IS 'The size of the set';

--- a/transmart-data/ddl/postgres/biomart_user/query_set_diff.sql
+++ b/transmart-data/ddl/postgres/biomart_user/query_set_diff.sql
@@ -1,5 +1,6 @@
 --
 -- Name: query_set_diff; Type: TABLE; Schema: biomart_user; Owner: -
+-- DEPRECATED! user queries related functionality has been moved to a gb-backend application
 --
 CREATE TABLE biomart_user.query_set_diff (
     id SERIAL PRIMARY KEY,
@@ -17,7 +18,7 @@ ALTER TABLE ONLY biomart_user.query_set_diff
 --
 -- Table documentation
 --
-COMMENT ON TABLE biomart_user.query_set_diff IS 'Table stores information about specific objects, deleted or added to the subscribed user query related set.';
+COMMENT ON TABLE biomart_user.query_set_diff IS 'Table stores information about specific objects, deleted or added to the subscribed user query related set. DEPRECATED! This table has been moved to a gb-backend application database.';
 
 COMMENT ON COLUMN biomart_user.query_set_diff.query_set_id IS 'Foreign key to id in query_set table.';
 COMMENT ON COLUMN biomart_user.query_set_diff.object_id IS 'The id of the object from the set that was updated, e.g. id of an i2b2demodata.patient_dimension instance.';

--- a/transmart-data/ddl/postgres/biomart_user/query_set_instance.sql
+++ b/transmart-data/ddl/postgres/biomart_user/query_set_instance.sql
@@ -1,5 +1,6 @@
 --
 -- Name: query_set_instance; Type: TABLE; Schema: biomart_user; Owner: -
+-- DEPRECATED! user queries related functionality has been moved to a gb-backend application
 --
 CREATE TABLE biomart_user.query_set_instance (
     id SERIAL PRIMARY KEY,
@@ -16,7 +17,7 @@ ALTER TABLE ONLY biomart_user.query_set_instance
 --
 -- Table documentation
 --
-COMMENT ON TABLE biomart_user.query_set_instance IS 'Table stores information about specific instances of the query set';
+COMMENT ON TABLE biomart_user.query_set_instance IS 'Table stores information about specific instances of the query set. DEPRECATED! This table has been moved to a gb-backend application.';
 
 COMMENT ON COLUMN biomart_user.query_set_instance.query_set_id IS 'Foreign key to id in query_set table.';
 COMMENT ON COLUMN biomart_user.query_set_instance.object_id IS 'The id of the object that is being represented by the set instance, e.g. id of an i2b2demodata.patient_dimension instance.';

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/NotificationsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/NotificationsSpec.groovy
@@ -11,7 +11,9 @@ import static config.Config.*
  * These tests requires transmart-notifications plugin and /v2/admin/notifications/notify endpoint
  * to be enabled and properly configured.
  * See transmart-notifications configuration description.
+ * @deprecated user queries related functionality has been moved to a gb-backend application
  */
+@Deprecated
 class NotificationsSpec extends RESTSpec {
 
     void 'test triggering email sending by a regular user is denied'() {

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/UserQuerySpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/UserQuerySpec.groovy
@@ -14,7 +14,9 @@ import static tests.rest.dimensions.*
 
 /**
  *  CRUD endpoint for user queries.
+ *  @deprecated user queries related functionality has been moved to a gb-backend application
  */
+@Deprecated
 class UserQuerySpec extends RESTSpec {
 
     def "list queries"() {

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/RestApiUrlMappings.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/RestApiUrlMappings.groovy
@@ -212,6 +212,11 @@ class RestApiUrlMappings {
             "/export/file_formats"(method: 'GET', controller: 'export', action: 'fileFormats') {
                 apiVersion = "v2"
             }
+            "/pedigree/relation_types"(method: 'GET', controller: 'relationType', action: 'index')
+
+            /**
+             * @deprecated user queries related functionality has been moved to a gb-backend application
+             */
             "/queries"(method: 'GET', controller: 'userQuery', action: 'index') {
                 apiVersion = "v2"
             }
@@ -226,9 +231,6 @@ class RestApiUrlMappings {
             }
             "/queries/$id"(method: 'DELETE', controller: 'userQuery', action: 'delete')
             "/queries/$queryId/sets"(method: 'GET', controller: 'userQuerySet', action: 'getSetChangesByQueryId')
-            "/pedigree/relation_types"(method: 'GET', controller: 'relationType', action: 'index')
-
-            // Deprecated administrator actions
             "/queries/sets/scan"(method: 'POST', controller: 'userQuerySet', action: 'scan')
 
             group "/admin", {

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/UserQueryController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/UserQueryController.groovy
@@ -23,6 +23,7 @@ import org.transmartproject.rest.user.AuthContext
 
 import static org.transmartproject.rest.misc.RequestUtils.checkForUnsupportedParams
 
+@Deprecated
 class UserQueryController {
 
     static responseFormats = ['json']

--- a/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/UserQuerySetController.groovy
+++ b/transmart-rest-api/grails-app/controllers/org/transmartproject/rest/UserQuerySetController.groovy
@@ -9,6 +9,7 @@ import org.transmartproject.rest.user.AuthContext
 
 import static org.transmartproject.rest.misc.RequestUtils.checkForUnsupportedParams
 
+@Deprecated
 class UserQuerySetController {
 
     @Autowired

--- a/transmart-rest-api/src/func-test/groovy/org/transmartproject/rest/v2/UserQueryControllerSpec.groovy
+++ b/transmart-rest-api/src/func-test/groovy/org/transmartproject/rest/v2/UserQueryControllerSpec.groovy
@@ -10,6 +10,7 @@ import org.transmartproject.rest.v2.V2ResourceSpec
 import static org.transmartproject.rest.utils.ResponseEntityUtils.toJson
 
 @Slf4j
+@Deprecated
 class UserQueryControllerSpec extends V2ResourceSpec {
 
     def grailsApplication


### PR DESCRIPTION
User queries related functionality has been extracted to a separate application - [gb-backend](https://github.com/thehyve/gb-backend).

[TMT-690](https://jira.thehyve.nl/browse/TMT-690)