### PR TITLE
Fix the batch count in transmart-copy.

### DIFF
--- a/transmart-copy/src/main/groovy/org/transmartproject/copy/Counter.groovy
+++ b/transmart-copy/src/main/groovy/org/transmartproject/copy/Counter.groovy
@@ -1,0 +1,20 @@
+package org.transmartproject.copy
+
+import groovy.transform.CompileStatic
+
+/**
+ * Counter
+ */
+@CompileStatic
+class Counter {
+    private int value = 0
+
+    int getValue() {
+        value
+    }
+
+    void increment() {
+        value++
+    }
+
+}


### PR DESCRIPTION
I noticed that on the command line, transmart copy always reports `[INFO] 1 batches of 500 inserted.`. This change fixes the reporting of number of batches.