### PR TITLE
Fix disabling of notifications quartz jobs

### DIFF
--- a/transmart-notifications/grails-app/jobs/org/transmartproject/notifications/QuerySetSubscriptionDailyJob.groovy
+++ b/transmart-notifications/grails-app/jobs/org/transmartproject/notifications/QuerySetSubscriptionDailyJob.groovy
@@ -13,7 +13,14 @@ import org.transmartproject.core.userquery.SubscriptionFrequency
 @Slf4j
 class QuerySetSubscriptionDailyJob {
 
-    static jobEnabled =  Holders.config.org.transmartproject.notifications.enabled
+    /**
+     * Quartz plugin configuration option.
+     * By default all jobs are considered enabled. Setting this property to false can disable the job.
+     *
+     * Value of this option is controlled in the notifications plugin descriptor.
+     * @see {@link org.transmartproject.notifications.TransmartNotificationsGrailsPlugin}
+     */
+    static jobEnabled
 
     QuerySetSubscriptionMailService querySetSubscriptionMailService
 

--- a/transmart-notifications/grails-app/jobs/org/transmartproject/notifications/QuerySetSubscriptionWeeklyJob.groovy
+++ b/transmart-notifications/grails-app/jobs/org/transmartproject/notifications/QuerySetSubscriptionWeeklyJob.groovy
@@ -1,6 +1,5 @@
 package org.transmartproject.notifications
 
-import grails.util.Holders
 import groovy.util.logging.Slf4j
 import org.transmartproject.core.userquery.SubscriptionFrequency
 
@@ -12,7 +11,14 @@ import org.transmartproject.core.userquery.SubscriptionFrequency
 @Slf4j
 class QuerySetSubscriptionWeeklyJob {
 
-    static jobEnabled =  Holders.config.org.transmartproject.notifications.enabled
+    /**
+     * Quartz plugin configuration option.
+     * By default all jobs are considered enabled. Setting this property to false can disable the job.
+     *
+     * Value of this option is controlled in the notifications plugin descriptor.
+     * @see {@link org.transmartproject.notifications.TransmartNotificationsGrailsPlugin}
+     */
+    static jobEnabled
 
     QuerySetSubscriptionMailService querySetSubscriptionMailService
     /**

--- a/transmart-notifications/src/main/groovy/org/transmartproject/notifications/TransmartNotificationsGrailsPlugin.groovy
+++ b/transmart-notifications/src/main/groovy/org/transmartproject/notifications/TransmartNotificationsGrailsPlugin.groovy
@@ -34,7 +34,15 @@ A plugin that provides an email subscription functionality.
 
     Closure doWithSpring() { {->
             // enable/disable the plugin
-            enabled = config.getProperty("org.transmartproject.notifications.enabled", Boolean, true)
+            enabled = config.getProperty("org.transmartproject.notifications.enabled", Boolean, false)
+            // enable/disable the daily quartz job scheduler
+            querySetSubscriptionDailyJob(QuerySetSubscriptionDailyJob) {
+                jobEnabled = enabled
+            }
+            // enable/disable the weekly quartz job scheduler
+            querySetSubscriptionWeeklyJob(QuerySetSubscriptionWeeklyJob) {
+                jobEnabled = enabled
+            }
         }
     }
 


### PR DESCRIPTION
Value of `Holders.config.org.transmartproject.notifications.enabled` was not properly resolved inside subscription job classes. 