### PR TITLE
Expect the same KEYCLOAK_SERVER_URL in all glowing-bear-docker components

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,7 +17,7 @@ can be used to configure Keycloak:
 
 Variable              | Default value
 ----------------------|---------------
-`KEYCLOAK_SERVER_URL` | https://keycloak-dwh-test.thehyve.net/auth
+`KEYCLOAK_SERVER_URL` | https://keycloak-dwh-test.thehyve.net
 `KEYCLOAK_REALM`      | transmart-dev
 `KEYCLOAK_CLIENT_ID`  | transmart-client
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - 9081:8081
     environment:
-      KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL:-https://keycloak-dwh-test.thehyve.net/auth}
+      KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL:-https://keycloak-dwh-test.thehyve.net}
       KEYCLOAK_REALM: ${KEYCLOAK_REALM:-transmart-dev}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_CLIENT_ID:-transmart-client}
       PGHOST: transmart-database

--- a/docker/transmart-api-server/docker-entrypoint.sh
+++ b/docker/transmart-api-server/docker-entrypoint.sh
@@ -46,7 +46,7 @@ org.transmartproject.system.writeLogToDatabase: false
 keycloak:
     realm: ${KEYCLOAK_REALM}
     bearer-only: true
-    auth-server-url: ${KEYCLOAK_SERVER_URL}
+    auth-server-url: ${KEYCLOAK_SERVER_URL}/auth
     resource: ${KEYCLOAK_CLIENT_ID}
     use-resource-role-mappings: true
 EndOfMessage


### PR DESCRIPTION
Expect `https://keycloak-example.com` (without `/auth` part)