### PR TITLE
Enable incremental loading of patient data for a study

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - DIR=transmart-api-server; TEST=check
     - DIR=transmart-batch; INSTALL=":transmart-data:createVars :transmart-data:setupPostgres travisPreparePostgres"; PREPARE=shadowJar; TEST=check
     - DIR=transmart-solr-indexing; INSTALL=":transmart-data:createVars :transmart-data:setupPostgresTest :transmart-batch:travisProperties :transmart-batch:loadPublicTestStudy"; TEST="check"; START_SOLR=true
-    - DIR=transmart-copy; INSTALL=":transmart-data:createVars :transmart-data:setupPostgresTest"; PREPARE=shadowJar; TEST=check
+    - DIR=transmart-copy; INSTALL=":transmart-data:createVars :transmart-data:setupPostgres"; PREPARE=shadowJar; TEST=check
     - DIR=transmart-schemas; PREPARE=assemble; TEST=check
     - DIR=.; TEST="publishToMavenLocal"
 

--- a/transmart-copy/README.md
+++ b/transmart-copy/README.md
@@ -35,6 +35,7 @@ _Parameters:_
 - `-d`, `--directory`: Specifies a data directory.
 - `-U`, `--update-concept-paths`: **Workaround.** Updates concept paths and tree nodes when there is concept code collision.
 - `-m`, `--mode <study|pedigree>`: Load mode. What type of data to load. Data loading does not happen if you skip the mode.
+- `-I`, `--incremental`: Enable incremental loading of patient data for a study (supported for a study mode).
 - `-p`, `--partition`: Partition observation_fact table based on `trial_visit_num` (Experimental).
 
 
@@ -94,6 +95,7 @@ The database settings are read from the environment variables:
 - `PGDATABASE`: the database name (default: `transmart`)
 - `PGUSER`: the database admin user (required)
 - `PGPASSWORD`: the password of the admin user (required)
+- `MAXPOOLSIZE`: maximum pool size to avoid too many clients connection issue in db (default: `8`)
 
 
 

--- a/transmart-copy/src/main/groovy/org/transmartproject/copy/Database.groovy
+++ b/transmart-copy/src/main/groovy/org/transmartproject/copy/Database.groovy
@@ -91,18 +91,14 @@ class Database implements AutoCloseable {
         if (!password) {
             throw new IllegalArgumentException('Please set the PGPASSWORD environment variable.')
         }
-        Integer maximumPoolSize
-        try{
-            maximumPoolSize = Integer.parseInt(params['MAXPOOLSIZE'])
-        } catch (NumberFormatException e) {
-            maximumPoolSize = 8
-        }
 
+        if (params['MAXPOOLSIZE']) {
+            config.maximumPoolSize = Integer.parseInt(params['MAXPOOLSIZE'])
+        }
         config.jdbcUrl = url
         config.username = username
         config.password = password
         config.autoCommit = false
-        config.maximumPoolSize = maximumPoolSize
         dataSource = new HikariDataSource(config)
 
         def dataSourceTransactionManager = new DataSourceTransactionManager()

--- a/transmart-copy/src/main/groovy/org/transmartproject/copy/Database.groovy
+++ b/transmart-copy/src/main/groovy/org/transmartproject/copy/Database.groovy
@@ -91,11 +91,18 @@ class Database implements AutoCloseable {
         if (!password) {
             throw new IllegalArgumentException('Please set the PGPASSWORD environment variable.')
         }
+        Integer maximumPoolSize
+        try{
+            maximumPoolSize = Integer.parseInt(params['MAXPOOLSIZE'])
+        } catch (NumberFormatException e) {
+            maximumPoolSize = 8
+        }
 
         config.jdbcUrl = url
         config.username = username
         config.password = password
         config.autoCommit = false
+        config.maximumPoolSize = maximumPoolSize
         dataSource = new HikariDataSource(config)
 
         def dataSourceTransactionManager = new DataSourceTransactionManager()

--- a/transmart-copy/src/main/groovy/org/transmartproject/copy/table/Patients.groovy
+++ b/transmart-copy/src/main/groovy/org/transmartproject/copy/table/Patients.groovy
@@ -149,4 +149,38 @@ class Patients {
         log.info "${insertCount} patients inserted."
     }
 
+    void removeObservations(String rootPath, Set<Long> trialVisitNums) {
+        LinkedHashMap<String, Class> header
+        def patientsFile = new File(rootPath, PATIENT_MAPPING_TABLE.fileName)
+        patientsFile.withReader { reader ->
+            def tsvReader = Util.tsvReader(reader)
+            tsvReader.eachWithIndex { String[] data, int i ->
+                if (i == 0) {
+                    header = Util.verifyHeader(PATIENT_MAPPING_TABLE.fileName, data, patientMappingColumns)
+                    return
+                }
+                def patientData = Util.asMap(header, data)
+                def patientIde = patientData['patient_ide'] as String
+                def patientIdeSource = patientData['patient_ide_source'] as String
+                def key = "${patientIdeSource}:${patientIde}".toString()
+                def patientNum = subjectIdToPatientNum[key]
+
+                removeObservationsForPatientAndTrials(patientNum, trialVisitNums)
+            }
+        }
+    }
+
+    private void removeObservationsForPatientAndTrials(Long patientNum, Set<Long> trialVisitNums) {
+        if (!trialVisitNums) {
+            return
+        }
+        int observationCount = database.namedParameterJdbcTemplate.update(
+                """delete from ${Observations.TABLE} where
+                patient_num = :patientNum and
+                trial_visit_num in (:trialVisitNums)""".toString(),
+                [patientNum: patientNum, trialVisitNums: trialVisitNums]
+        )
+        log.info "${observationCount} observations deleted from ${Observations.TABLE}."
+    }
+
 }

--- a/transmart-copy/src/main/groovy/org/transmartproject/copy/table/Studies.groovy
+++ b/transmart-copy/src/main/groovy/org/transmartproject/copy/table/Studies.groovy
@@ -39,6 +39,7 @@ class Studies {
     final LinkedHashMap<String, ColumnMetadata> studyDimensionsColumns
 
     final Map<String, Long> studyIdToStudyNum = [:]
+    final Map<Long, List<Long>> studyNumToDimensionDescriptionId = [:]
     final List<Long> indexToStudyNum = []
     final List<Long> indexToTrialVisitNum = []
 
@@ -72,16 +73,31 @@ class Studies {
         }
     }
 
-    Study findStudy(String studyId) {
-        def studies = database.namedParameterJdbcTemplate.query(
-                "select * from ${STUDY_TABLE} where study_id = :studyId".toString(),
-                [studyId: studyId],
-                new StudyRowMapper()
-        )
-        if (studies.size() == 0) {
-            return null
+    @CompileStatic
+    static class StudyRowHandler implements RowCallbackHandler {
+        final Map<String, Long> studyIdToStudyNum = [:]
+
+        @Override
+        void processRow(ResultSet rs) throws SQLException {
+            def studyId = rs.getString('study_id')
+            Long studyNum = rs.getLong('study_num')
+            studyIdToStudyNum[studyId] = studyNum
         }
-        studies[0]
+    }
+
+    @CompileStatic
+    static class StudyDimensionDescriptionRowHandler implements RowCallbackHandler {
+        final Map<Long, List<Long>> studyNumToDimensionDescriptionId = [:]
+
+        @Override
+        void processRow(ResultSet rs) throws SQLException {
+            Long studyId = rs.getLong('study_id')
+            Long dimensionDescriptionId = rs.getLong('dimension_description_id')
+            if (!studyNumToDimensionDescriptionId.containsKey(studyId)) {
+                studyNumToDimensionDescriptionId[studyId] = []
+            }
+            studyNumToDimensionDescriptionId[studyId].add(dimensionDescriptionId)
+        }
     }
 
     @CompileStatic
@@ -94,7 +110,49 @@ class Studies {
         }
     }
 
-    List<Long> findTrialVisitNumsForStudy(Long studyNum) {
+    Study findStudy(String studyId) {
+        def studies = database.namedParameterJdbcTemplate.query(
+                "select * from ${STUDY_TABLE} where study_id = :studyId".toString(),
+                [studyId: studyId],
+                new StudyRowMapper()
+        )
+        if (studies.size() == 0) {
+            return null
+        }
+        studies[0]
+    }
+
+    void fetch() {
+        def studyHandler = new StudyRowHandler()
+        database.jdbcTemplate.query(
+                "select study_id, study_num from ${STUDY_TABLE}".toString(),
+                studyHandler
+        )
+        studyIdToStudyNum.putAll(studyHandler.studyIdToStudyNum)
+        indexToStudyNum.addAll(studyHandler.studyIdToStudyNum.values())
+        log.info "Study entries in the database: ${studyIdToStudyNum.size()}."
+    }
+
+    void fetchStudyDimensionDescriptions() {
+        def studyDimensionDescriptionHandler = new StudyDimensionDescriptionRowHandler()
+        database.jdbcTemplate.query(
+                "select study_id, dimension_description_id from ${STUDY_DIMENSIONS_TABLE}".toString(),
+                studyDimensionDescriptionHandler
+        )
+        studyNumToDimensionDescriptionId.putAll(studyDimensionDescriptionHandler.studyNumToDimensionDescriptionId)
+        log.info "Study dimension description entries in the database: ${studyIdToStudyNum.size()}."
+    }
+
+    List<Long> findTrialVisitNumsForStudyId(String studyId) {
+        def study = findStudy(studyId)
+        if (!study) {
+            log.info("No ${studyId} found.")
+            return []
+        }
+        findTrialVisitNumsForStudyNum(study.studyNum)
+    }
+
+    List<Long> findTrialVisitNumsForStudyNum(Long studyNum) {
         def trialVisitHandler = new TrialVisitRowHandler()
         database.namedParameterJdbcTemplate.query(
                 "select trial_visit_num from ${TRIAL_VISIT_TABLE} where study_num = :studyNum".toString(),
@@ -136,7 +194,7 @@ class Studies {
             }
         }
         log.info "Deleting observations for study ${studyId} ..."
-        List<Long> trialVisitNums = findTrialVisitNumsForStudy(study.studyNum)
+        List<Long> trialVisitNums = findTrialVisitNumsForStudyNum(study.studyNum)
         removeObservationsForTrials(trialVisitNums as Set)
 
         log.info "Deleting trial visits for study ${studyId} ..."
@@ -180,8 +238,10 @@ class Studies {
     void checkIfStudyExists(String studyId) {
         def study = findStudy(studyId)
         if (study) {
+
             log.error "Found existing study: ${study}."
-            log.error "You can delete the study and associated data with: `transmart-copy --delete ${studyId}`."
+            log.error "You can delete the study and associated data with: `transmart-copy --delete ${studyId}` " +
+                      "or load data incrementally with: `transmart-copy --incremental`."
             throw new IllegalStateException("Study already exists: ${studyId}.")
         }
         log.info "Study ${studyId} does not exists in the database yet."
@@ -198,11 +258,7 @@ class Studies {
                     return
                 }
                 def studyData = Util.asMap(header, data)
-                def studyIndex = studyData['study_num'] as long
-                if (i != studyIndex + 1) {
-                    throw new IllegalStateException(
-                            "The studies ${STUDY_TABLE.fileName} are not in order. (Found ${studyIndex} on line ${i}.)")
-                }
+                verifyStudiesOrder(studyData, i)
                 def studyId = studyData['study_id'] as String
                 checkIfStudyExists(studyId)
             }
@@ -210,6 +266,14 @@ class Studies {
     }
 
     void delete(String rootPath, boolean failOnNoStudy = true) {
+        def studyIds = readStudyIds(rootPath)
+        for (String studyId : studyIds) {
+            deleteById(studyId, failOnNoStudy)
+        }
+    }
+
+    List<String> readStudyIds(String rootPath) {
+        List<String> studyIds = []
         LinkedHashMap<String, Class> header
         def studiesFile = new File(rootPath, STUDY_TABLE.fileName)
         studiesFile.withReader { reader ->
@@ -220,9 +284,18 @@ class Studies {
                     return
                 }
                 def studyData = Util.asMap(header, data)
-                def studyId = studyData['study_id'] as String
-                deleteById(studyId, failOnNoStudy)
+                verifyStudiesOrder(studyData, i)
+                studyIds.add(studyData['study_id'] as String)
             }
+        }
+        studyIds
+    }
+
+    private void verifyStudiesOrder(Map<String, Object> studyData, int i) {
+        def studyIndex = studyData['study_num'] as long
+        if (i != studyIndex + 1) {
+            throw new IllegalStateException(
+                    "The studies ${STUDY_TABLE.fileName} are not in order. (Found ${studyIndex} on line ${i}.)")
         }
     }
 
@@ -240,10 +313,12 @@ class Studies {
                 try {
                     def studyData = Util.asMap(studyHeader, data)
                     def studyId = studyData['study_id'] as String
-                    def studyNum = database.insertEntry(STUDY_TABLE, studyHeader, 'study_num', studyData)
-                    log.info "Study ${studyId} inserted [study_num: ${studyNum}]."
-                    indexToStudyNum.add(studyNum)
-                    studyIdToStudyNum[studyId] = studyNum
+                    if (!studyIdToStudyNum.containsKey(studyId)) {
+                        def studyNum = database.insertEntry(STUDY_TABLE, studyHeader, 'study_num', studyData)
+                        log.info "Study ${studyId} inserted [study_num: ${studyNum}]."
+                        indexToStudyNum.add(studyNum)
+                        studyIdToStudyNum[studyId] = studyNum
+                    }
                 } catch(Throwable e) {
                     log.error "Error on line ${i} of ${STUDY_TABLE.fileName}: ${e.message}."
                     throw e
@@ -306,7 +381,6 @@ class Studies {
                                 "Invalid study index (${studyIndex}). Only ${indexToStudyNum.size()} studies found.")
                     }
                     def studyNum = indexToStudyNum[studyIndex]
-                    studyDimensionData['study_id'] = studyNum
                     def dimensionIndex = studyDimensionData['dimension_description_id'] as int
                     if (dimensionIndex >= dimensions.indexToDimensionId.size()) {
                         throw new IllegalStateException(
@@ -314,11 +388,15 @@ class Studies {
                                         "Only ${dimensions.indexToDimensionId.size()} dimensions found.")
                     }
                     def dimensionId = dimensions.indexToDimensionId[dimensionIndex]
-                    studyDimensionData['dimension_description_id'] = dimensionId
-                    database.insertEntry(STUDY_DIMENSIONS_TABLE, studyDimensionsHeader, studyDimensionData)
-                    insertCount++
-                    log.debug "Study dimension inserted [study_id: ${studyNum}, " +
-                            "dimension_description_id: ${dimensionId}]."
+                    if (!(studyNumToDimensionDescriptionId.containsKey(studyNum) &&
+                          studyNumToDimensionDescriptionId[studyNum].contains(dimensionId))) {
+                        studyDimensionData['study_id'] = studyNum
+                        studyDimensionData['dimension_description_id'] = dimensionId
+                        database.insertEntry(STUDY_DIMENSIONS_TABLE, studyDimensionsHeader, studyDimensionData)
+                        insertCount++
+                        log.debug "Study dimension inserted [study_id: ${studyNum}, " +
+                                "dimension_description_id: ${dimensionId}]."
+                    }
                 } catch(Throwable e) {
                     log.error "Error on line ${i} of ${STUDY_DIMENSIONS_TABLE.fileName}: ${e.message}."
                     throw e

--- a/transmart-copy/src/test/groovy/org/transmartproject/copy/CopySpec.groovy
+++ b/transmart-copy/src/test/groovy/org/transmartproject/copy/CopySpec.groovy
@@ -363,13 +363,13 @@ class CopySpec extends Specification {
 
         // observation for patient from part1 only - old value
         readFieldsFromDb(Observations.TABLE,'nval_num',
-                "where patient_num=${inDbPatientIdeToPatientNum['SURVEY_INC_P2']} AND concept_cd='age'")[0] == 33
+                "where patient_num=${inDbPatientIdeToPatientNum['SURVEY_INC_P2']} AND concept_cd='age'") == [33]
         // observation for patient updated in part2 - updated value
         readFieldsFromDb(Observations.TABLE,'nval_num',
-                "where patient_num=${inDbPatientIdeToPatientNum['SURVEY_INC_P1']} AND concept_cd='age'")[0] == 26
+                "where patient_num=${inDbPatientIdeToPatientNum['SURVEY_INC_P1']} AND concept_cd='age'") == [26]
         // observation for patient added in part2 - new value
         readFieldsFromDb(Observations.TABLE,'nval_num',
-                "where patient_num=${inDbPatientIdeToPatientNum['SURVEY_INC_P3']} AND concept_cd='age'")[0] == 60
+                "where patient_num=${inDbPatientIdeToPatientNum['SURVEY_INC_P3']} AND concept_cd='age'") == [60]
     }
 
     def 'test incremental loading of the same data'() {
@@ -415,9 +415,9 @@ class CopySpec extends Specification {
 
         then: 'observations from a different study for the shared patient are not changed'
         observationsForSharedUserBeforeUpdate.size() == 2
-        observationsForSharedUserBeforeUpdate == [42.0000000000000000, 24.0000000000000000]
+        observationsForSharedUserBeforeUpdate.containsAll([42.0000000000000000, 24.0000000000000000])
         observationsForSharedUserAfterUpdate.size() == 2
-        observationsForSharedUserAfterUpdate == [42.0000000000000000, 26.0000000000000000]
+        observationsForSharedUserAfterUpdate.containsAll([42.0000000000000000, 26.0000000000000000])
     }
 
     List<Number> getTestTrialVisitsDbIdentifiers() {

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/concept_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/concept_dimension.tsv
@@ -1,0 +1,4 @@
+concept_cd	concept_path	name_char	concept_blob	update_date	download_date	import_date	sourcesystem_cd	upload_id	table_name
+height	\Demographics\Height\	Height							
+age	\Demographics\Age\	Age							
+gender	\Demographics\Gender\	Gender							

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/modifier_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/modifier_dimension.tsv
@@ -1,0 +1,2 @@
+modifier_path	modifier_cd	name_char	modifier_blob	update_date	download_date	import_date	sourcesystem_cd	upload_id	modifier_level	modifier_node_type
+\Missing Value	MISSVAL	Missing Value								

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/observation_fact.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/observation_fact.tsv
@@ -1,0 +1,7 @@
+encounter_num	patient_num	concept_cd	provider_id	start_date	modifier_cd	instance_num	trial_visit_num	valtype_cd	tval_char	nval_num	valueflag_cd	quantity_num	units_cd	end_date	location_cd	observation_blob	confidence_num	update_date	download_date	import_date	sourcesystem_cd	upload_id	sample_cd
+-1	0	gender	@	2019-03-21 10:36:01	@	1	0	T	Male														
+-1	1	gender	@	2019-12-16 20:23:15	@	1	0	T	Female														
+-1	0	age	@	2019-03-21 10:36:01	@	1	0	N	E	24													
+-1	1	age	@	2019-12-16 20:23:15	@	1	0	N	E	33													
+-1	0	height	@	2019-03-21 10:36:01	@	1	0	N	E	184													
+-1	1	height	@	2019-12-16 20:23:15	@	1	0	N	E	163													

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/patient_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/patient_dimension.tsv
@@ -1,0 +1,3 @@
+patient_num	vital_status_cd	birth_date	death_date	sex_cd	age_in_years_num	language_cd	race_cd	marital_status_cd	religion_cd	zip_cd	statecityzip_path	income_cd	patient_blob	update_date	download_date	import_date	sourcesystem_cd	upload_id
+0				Male	24												SURVEY_INC_P1	
+1				Female	33												SURVEY_INC_P2	

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/patient_mapping.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/patient_mapping.tsv
@@ -1,0 +1,3 @@
+patient_ide	patient_ide_source	patient_num	patient_ide_status	upload_date	update_date	download_date	import_date	sourcesystem_cd	upload_id
+SURVEY_INC_P1	SUBJ_ID	0							
+SURVEY_INC_P2	SUBJ_ID	1							

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/study.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/study.tsv
@@ -1,0 +1,2 @@
+study_num	bio_experiment_id	study_id	secure_obj_token	study_blob
+0		SURVEY_INC	SURVEY_INC	

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/trial_visit_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2demodata/trial_visit_dimension.tsv
@@ -1,0 +1,2 @@
+trial_visit_num	study_num	rel_time_unit_cd	rel_time_num	rel_time_label
+0	0			Day 1

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/dimension_description.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/dimension_description.tsv
@@ -1,0 +1,6 @@
+id	density	modifier_code	value_type	name	packable	size_cd	dimension_type	sort_index
+0				study				
+1				concept				
+2				patient				
+3				start time				
+4	DENSE	MISSVAL	T	missing_value	NOT_PACKABLE	SMALL		

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/i2b2_secure.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/i2b2_secure.tsv
@@ -1,0 +1,4 @@
+c_hlevel	c_fullname	c_name	c_synonym_cd	c_visualattributes	c_totalnum	c_basecode	c_metadataxml	c_facttablecolumn	c_tablename	c_columnname	c_columndatatype	c_operator	c_dimcode	c_comment	c_tooltip	m_applied_path	update_date	download_date	import_date	sourcesystem_cd	valuetype_cd	m_exclusion_cd	c_path	c_symbol	i2b2_id	secure_obj_token
+3	\Projects\Survey_Inc\part1\Demographics\Gender\	Gender	N	LAC		gender		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Gender\			@				SURVEY_INC						SURVEY_INC
+3	\Projects\Survey_Inc\part1\Demographics\Age\	Age	N	LAN		age		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Age\			@				SURVEY_INC						SURVEY_INC
+3	\Projects\Survey_Inc\part2\Demographics\Height\	Height	N	LAN		height		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Height\			@				SURVEY_INC						SURVEY_INC

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/i2b2_secure.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/i2b2_secure.tsv
@@ -1,4 +1,7 @@
 c_hlevel	c_fullname	c_name	c_synonym_cd	c_visualattributes	c_totalnum	c_basecode	c_metadataxml	c_facttablecolumn	c_tablename	c_columnname	c_columndatatype	c_operator	c_dimcode	c_comment	c_tooltip	m_applied_path	update_date	download_date	import_date	sourcesystem_cd	valuetype_cd	m_exclusion_cd	c_path	c_symbol	i2b2_id	secure_obj_token
-3	\Projects\Survey_Inc\part1\Demographics\Gender\	Gender	N	LAC		gender		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Gender\			@				SURVEY_INC						SURVEY_INC
-3	\Projects\Survey_Inc\part1\Demographics\Age\	Age	N	LAN		age		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Age\			@				SURVEY_INC						SURVEY_INC
-3	\Projects\Survey_Inc\part2\Demographics\Height\	Height	N	LAN		height		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Height\			@				SURVEY_INC						SURVEY_INC
+1	\Projects\Survey_Inc\	Survey_Inc 1	N	FAS				@	STUDY	STUDY_ID	T	=	SURVEY_INC			@				SURVEY_INC						SURVEY_INC
+0	\Projects\	Projects	N	CA				@	@	@	T	=				@										PUBLIC
+2	\Projects\Survey_Inc\Demographics\	Demographics	N	FA				CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\			@				SURVEY_INC						SURVEY_INC
+3	\Projects\Survey_Inc\Demographics\Gender\	Gender	N	LAC		gender		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Gender\			@				SURVEY_INC						SURVEY_INC
+3	\Projects\Survey_Inc\Demographics\Age\	Age	N	LAN		age		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Age\			@				SURVEY_INC						SURVEY_INC
+3	\Projects\Survey_Inc\Demographics\Height\	Height	N	LAN		height		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Height\			@				SURVEY_INC						SURVEY_INC

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/i2b2_tags.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/i2b2_tags.tsv
@@ -1,2 +1,2 @@
 tag_id	path	tag	tag_type	tags_idx	tag_option_id
-1	\Projects\Survey_Inc\part1\Demographics\Gender\	sex	item_name	1	
+1	\Projects\Survey_Inc\Demographics\Gender\	sex	item_name	1	

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/i2b2_tags.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/i2b2_tags.tsv
@@ -1,0 +1,2 @@
+tag_id	path	tag	tag_type	tags_idx	tag_option_id
+1	\Projects\Survey_Inc\part1\Demographics\Gender\	sex	item_name	1	

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/study_dimension_descriptions.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part1/i2b2metadata/study_dimension_descriptions.tsv
@@ -1,0 +1,6 @@
+dimension_description_id	study_id
+0	0
+1	0
+2	0
+3	0
+4	0

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/concept_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/concept_dimension.tsv
@@ -1,0 +1,4 @@
+concept_cd	concept_path	name_char	concept_blob	update_date	download_date	import_date	sourcesystem_cd	upload_id	table_name
+height	\Demographics\Height\	Height							
+age	\Demographics\Age\	Age							
+gender	\Demographics\Gender\	Gender							

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/modifier_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/modifier_dimension.tsv
@@ -1,0 +1,2 @@
+modifier_path	modifier_cd	name_char	modifier_blob	update_date	download_date	import_date	sourcesystem_cd	upload_id	modifier_level	modifier_node_type
+\Missing Value	MISSVAL	Missing Value								

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/observation_fact.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/observation_fact.tsv
@@ -1,7 +1,7 @@
 encounter_num	patient_num	concept_cd	provider_id	start_date	modifier_cd	instance_num	trial_visit_num	valtype_cd	tval_char	nval_num	valueflag_cd	quantity_num	units_cd	end_date	location_cd	observation_blob	confidence_num	update_date	download_date	import_date	sourcesystem_cd	upload_id	sample_cd
 -1	0	gender	@	2019-03-21 10:36:01	@	1	0	T	Male														
 -1	1	gender	@	2015-12-16 20:23:15	@	1	0	T	Male														
--1	0	age	@	2019-03-21 10:36:01	@	1	0	N	E	24													
+-1	0	age	@	2019-03-21 10:36:01	@	1	0	N	E	26													
 -1	1	age	@	2015-12-16 20:23:15	@	1	0	N	E	60													
 -1	0	height	@	2019-03-21 10:36:01	@	1	0	N	E	184													
 -1	1	height	@	2015-12-16 20:23:15	@	1	0	N	E	170													

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/observation_fact.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/observation_fact.tsv
@@ -1,0 +1,7 @@
+encounter_num	patient_num	concept_cd	provider_id	start_date	modifier_cd	instance_num	trial_visit_num	valtype_cd	tval_char	nval_num	valueflag_cd	quantity_num	units_cd	end_date	location_cd	observation_blob	confidence_num	update_date	download_date	import_date	sourcesystem_cd	upload_id	sample_cd
+-1	0	gender	@	2019-03-21 10:36:01	@	1	0	T	Male														
+-1	1	gender	@	2015-12-16 20:23:15	@	1	0	T	Male														
+-1	0	age	@	2019-03-21 10:36:01	@	1	0	N	E	24													
+-1	1	age	@	2015-12-16 20:23:15	@	1	0	N	E	60													
+-1	0	height	@	2019-03-21 10:36:01	@	1	0	N	E	184													
+-1	1	height	@	2015-12-16 20:23:15	@	1	0	N	E	170													

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/patient_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/patient_dimension.tsv
@@ -1,0 +1,3 @@
+patient_num	vital_status_cd	birth_date	death_date	sex_cd	age_in_years_num	language_cd	race_cd	marital_status_cd	religion_cd	zip_cd	statecityzip_path	income_cd	patient_blob	update_date	download_date	import_date	sourcesystem_cd	upload_id
+0				Male	24												SURVEY_INC_P1	
+1				Male	60												SURVEY_INC_P3	

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/patient_mapping.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/patient_mapping.tsv
@@ -1,0 +1,3 @@
+patient_ide	patient_ide_source	patient_num	patient_ide_status	upload_date	update_date	download_date	import_date	sourcesystem_cd	upload_id
+SURVEY_INC_P1	SUBJ_ID	0							
+SURVEY_INC_P3	SUBJ_ID	1							

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/study.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/study.tsv
@@ -1,0 +1,2 @@
+study_num	bio_experiment_id	study_id	secure_obj_token	study_blob
+0		SURVEY_INC	SURVEY_INC	

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/trial_visit_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2demodata/trial_visit_dimension.tsv
@@ -1,0 +1,2 @@
+trial_visit_num	study_num	rel_time_unit_cd	rel_time_num	rel_time_label
+0	0			Day 1

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/dimension_description.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/dimension_description.tsv
@@ -1,0 +1,6 @@
+id	density	modifier_code	value_type	name	packable	size_cd	dimension_type	sort_index
+0				study				
+1				concept				
+2				patient				
+3				start time				
+4	DENSE	MISSVAL	T	missing_value	NOT_PACKABLE	SMALL		

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/i2b2_secure.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/i2b2_secure.tsv
@@ -1,4 +1,7 @@
 c_hlevel	c_fullname	c_name	c_synonym_cd	c_visualattributes	c_totalnum	c_basecode	c_metadataxml	c_facttablecolumn	c_tablename	c_columnname	c_columndatatype	c_operator	c_dimcode	c_comment	c_tooltip	m_applied_path	update_date	download_date	import_date	sourcesystem_cd	valuetype_cd	m_exclusion_cd	c_path	c_symbol	i2b2_id	secure_obj_token
-3	\Projects\Survey_Inc\part2\Demographics\Gender\	Gender	N	LAC		gender		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Gender\			@				SURVEY_INC						SURVEY_INC
-3	\Projects\Survey_Inc\part1\Demographics\Age\	Age	N	LAN		age		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Age\			@				SURVEY_INC						SURVEY_INC
-3	\Projects\Survey_Inc\part1\Demographics\Height\	Height	N	LAN		height		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Height\			@				SURVEY_INC						SURVEY_INC
+1	\Projects\Survey_Inc\	Survey_Inc 1	N	FAS				@	STUDY	STUDY_ID	T	=	SURVEY_INC			@				SURVEY_INC						SURVEY_INC
+0	\Projects\	Projects	N	CA				@	@	@	T	=				@										PUBLIC
+2	\Projects\Survey_Inc\Demographics\	Demographics	N	FA				CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\			@				SURVEY_INC						SURVEY_INC
+3	\Projects\Survey_Inc\Demographics\Gender\	Gender	N	LAC		gender		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Gender\			@				SURVEY_INC						SURVEY_INC
+3	\Projects\Survey_Inc\Demographics\Age\	Age	N	LAN		age		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Age\			@				SURVEY_INC						SURVEY_INC
+3	\Projects\Survey_Inc\Demographics\Height\	Height	N	LAN		height		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Height\			@				SURVEY_INC						SURVEY_INC

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/i2b2_secure.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/i2b2_secure.tsv
@@ -1,0 +1,4 @@
+c_hlevel	c_fullname	c_name	c_synonym_cd	c_visualattributes	c_totalnum	c_basecode	c_metadataxml	c_facttablecolumn	c_tablename	c_columnname	c_columndatatype	c_operator	c_dimcode	c_comment	c_tooltip	m_applied_path	update_date	download_date	import_date	sourcesystem_cd	valuetype_cd	m_exclusion_cd	c_path	c_symbol	i2b2_id	secure_obj_token
+3	\Projects\Survey_Inc\part2\Demographics\Gender\	Gender	N	LAC		gender		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Gender\			@				SURVEY_INC						SURVEY_INC
+3	\Projects\Survey_Inc\part1\Demographics\Age\	Age	N	LAN		age		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Age\			@				SURVEY_INC						SURVEY_INC
+3	\Projects\Survey_Inc\part1\Demographics\Height\	Height	N	LAN		height		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Height\			@				SURVEY_INC						SURVEY_INC

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/i2b2_tags.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/i2b2_tags.tsv
@@ -1,2 +1,2 @@
 tag_id	path	tag	tag_type	tags_idx	tag_option_id
-1	\Projects\Survey_Inc\part2\Demographics\Gender\	sex	item_name	1	
+1	\Projects\Survey_Inc\Demographics\Gender\	sex	item_name	1	

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/i2b2_tags.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/i2b2_tags.tsv
@@ -1,0 +1,2 @@
+tag_id	path	tag	tag_type	tags_idx	tag_option_id
+1	\Projects\Survey_Inc\part2\Demographics\Gender\	sex	item_name	1	

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/study_dimension_descriptions.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC/part2/i2b2metadata/study_dimension_descriptions.tsv
@@ -1,0 +1,6 @@
+dimension_description_id	study_id
+0	0
+1	0
+2	0
+3	0
+4	0

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/concept_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/concept_dimension.tsv
@@ -1,0 +1,2 @@
+concept_cd	concept_path	name_char	concept_blob	update_date	download_date	import_date	sourcesystem_cd	upload_id	table_name
+age	\Demographics\Age\	Age							

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/modifier_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/modifier_dimension.tsv
@@ -1,0 +1,2 @@
+modifier_path	modifier_cd	name_char	modifier_blob	update_date	download_date	import_date	sourcesystem_cd	upload_id	modifier_level	modifier_node_type
+\Missing Value	MISSVAL	Missing Value								

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/observation_fact.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/observation_fact.tsv
@@ -1,0 +1,2 @@
+encounter_num	patient_num	concept_cd	provider_id	start_date	modifier_cd	instance_num	trial_visit_num	valtype_cd	tval_char	nval_num	valueflag_cd	quantity_num	units_cd	end_date	location_cd	observation_blob	confidence_num	update_date	download_date	import_date	sourcesystem_cd	upload_id	sample_cd
+-1	0	age	@	2001-03-21 10:36:01	@	1	0	N	E	42													

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/patient_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/patient_dimension.tsv
@@ -1,0 +1,2 @@
+patient_num	vital_status_cd	birth_date	death_date	sex_cd	age_in_years_num	language_cd	race_cd	marital_status_cd	religion_cd	zip_cd	statecityzip_path	income_cd	patient_blob	update_date	download_date	import_date	sourcesystem_cd	upload_id
+0				Male	24												SURVEY_INC_P1	

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/patient_mapping.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/patient_mapping.tsv
@@ -1,0 +1,2 @@
+patient_ide	patient_ide_source	patient_num	patient_ide_status	upload_date	update_date	download_date	import_date	sourcesystem_cd	upload_id
+SURVEY_INC_P1	SUBJ_ID	0							

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/study.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/study.tsv
@@ -1,0 +1,2 @@
+study_num	bio_experiment_id	study_id	secure_obj_token	study_blob
+0		SURVEY_INC2_SHARED_PATIENT	SURVEY_INC2_SHARED_PATIENT	

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/trial_visit_dimension.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2demodata/trial_visit_dimension.tsv
@@ -1,0 +1,2 @@
+trial_visit_num	study_num	rel_time_unit_cd	rel_time_num	rel_time_label
+0	0			YEAR 10

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2metadata/dimension_description.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2metadata/dimension_description.tsv
@@ -1,0 +1,6 @@
+id	density	modifier_code	value_type	name	packable	size_cd	dimension_type	sort_index
+0				study				
+1				concept				
+2				patient				
+3				start time				
+4	DENSE	MISSVAL	T	missing_value	NOT_PACKABLE	SMALL		

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2metadata/i2b2_secure.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2metadata/i2b2_secure.tsv
@@ -1,0 +1,2 @@
+c_hlevel	c_fullname	c_name	c_synonym_cd	c_visualattributes	c_totalnum	c_basecode	c_metadataxml	c_facttablecolumn	c_tablename	c_columnname	c_columndatatype	c_operator	c_dimcode	c_comment	c_tooltip	m_applied_path	update_date	download_date	import_date	sourcesystem_cd	valuetype_cd	m_exclusion_cd	c_path	c_symbol	i2b2_id	secure_obj_token
+3	\Projects\Survey_Inc2_Shared_Patient\Demographics\Age\	Age	N	LAN		age		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Age\			@				SURVEY_INC2_SHARED_PATIENT						SURVEY_INC2_SHARED_PATIENT

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2metadata/i2b2_secure.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2metadata/i2b2_secure.tsv
@@ -1,2 +1,5 @@
 c_hlevel	c_fullname	c_name	c_synonym_cd	c_visualattributes	c_totalnum	c_basecode	c_metadataxml	c_facttablecolumn	c_tablename	c_columnname	c_columndatatype	c_operator	c_dimcode	c_comment	c_tooltip	m_applied_path	update_date	download_date	import_date	sourcesystem_cd	valuetype_cd	m_exclusion_cd	c_path	c_symbol	i2b2_id	secure_obj_token
-3	\Projects\Survey_Inc2_Shared_Patient\Demographics\Age\	Age	N	LAN		age		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Age\			@				SURVEY_INC2_SHARED_PATIENT						SURVEY_INC2_SHARED_PATIENT
+1	\Projects\Survey_Inc2_Shared_Patient\	Survey_Inc2_Shared_Patient 1	N	FAS				@	STUDY	STUDY_ID	T	=	SURVEY_INC2_SHARED_PATIENT			@				SURVEY_INC2_SHARED_PATIENT						SURVEY_INC2_SHARED_PATIENT
+0	\Projects\	Projects	N	CA				@	@	@	T	=				@										PUBLIC
+3	\Projects\Survey_Inc2_Shared_Patient\Demographics\	Demographics	N	FA				CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\			@				SURVEY_INC2_SHARED_PATIENT						SURVEY_INC2_SHARED_PATIENT
+4	\Projects\Survey_Inc2_Shared_Patient\Demographics\Age\	Age	N	LAN		age		CONCEPT_CD	CONCEPT_DIMENSION	CONCEPT_PATH	T	LIKE	\Demographics\Age\			@				SURVEY_INC2_SHARED_PATIENT						SURVEY_INC2_SHARED_PATIENT

--- a/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2metadata/study_dimension_descriptions.tsv
+++ b/transmart-copy/src/test/resources/examples/SURVEY_INC2_SHARED_PATIENT/i2b2metadata/study_dimension_descriptions.tsv
@@ -1,0 +1,6 @@
+dimension_description_id	study_id
+0	0
+1	0
+2	0
+3	0
+4	0


### PR DESCRIPTION
Implements [TMT-832](https://jira.thehyve.nl/browse/TMT-832)
- incremental study loading can be triggered by a new command line option: `-I` or `--incremental`
- with incremental option not all observations for the studies in the input data are deleted before loading (default behavior), but only the observations for the patients in the input data

Scenarios covered by tests:
- [x] inserts of new patient records in a next upload batch for a study, 
- [x] updates of existing patients,
- [x] deletes of patient records (present in a first upload part, but not in a second one),  
- [x] data for a patient is present in multiple studies