### PR TITLE
Make scan and cache rebuild tasks optional for after_data_loading_update

### DIFF
--- a/open-api/swagger.yaml
+++ b/open-api/swagger.yaml
@@ -2913,8 +2913,10 @@ paths:
     get:
       description: |
         This endpoint should be called after loading, deleting or updating data in the database.
-        It does different cache levels recalculations. Clears tree nodes, counts and patient set ids caches. Rebuilds the tree node cache per user.
-        Refreshes the bitsets materialized view. Updates data for subscribed user queries.
+        It does different cache levels recalculations. Clears tree nodes, counts and patient set ids caches.
+        Refreshes the bitsets materialized view.
+        If the offline token is configured, it also rebuilds the tree node cache per user
+        and updates data for subscribed user queries.
         Only for administrators.
       tags:
         - v2


### PR DESCRIPTION
Run scan and cache rebuild tasks only if the offline token is specified in the configuration.

Fixes [TMT-825](https://jira.thehyve.nl/browse/TMT-825).
There is still an issue when running after_data_loading_update and when the database was created using liquibase scripts (to be fixed by [TMT-919](https://jira.thehyve.nl/secure/RapidBoard.jspa?rapidView=124&projectKey=TMT&view=detail&selectedIssue=TMT-919) 