### PR TITLE
Rest Api e2e tests updates

### DIFF
--- a/transmart-data/test_data/studies/SHARED_CONCEPTS_STUDY_A/i2b2demodata/study.tsv
+++ b/transmart-data/test_data/studies/SHARED_CONCEPTS_STUDY_A/i2b2demodata/study.tsv
@@ -1,11 +1,1 @@
-"-27"	"-17"	"SHARED_CONCEPTS_STUDY_A"	"PUBLIC"	"{
-    ""defaultTabularRepresentation"": {
-        ""rowDimensions"": [
-            ""patient"",
-            ""study""
-        ],
-        ""columnDimensions"": [
-            ""concept""
-        ]
-    }
-}"
+-27	-17	SHARED_CONCEPTS_STUDY_A	PUBLIC	

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/NotificationsSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/NotificationsSpec.groovy
@@ -2,6 +2,7 @@ package tests.rest.v2
 
 import base.RESTSpec
 import base.RestHelper
+import org.junit.Ignore
 import org.transmartproject.core.multidimquery.ErrorResponse
 
 import static base.ContentTypeFor.JSON
@@ -14,6 +15,7 @@ import static config.Config.*
  * @deprecated user queries related functionality has been moved to a gb-backend application
  */
 @Deprecated
+@Ignore
 class NotificationsSpec extends RESTSpec {
 
     void 'test triggering email sending by a regular user is denied'() {

--- a/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/StudiesSpec.groovy
+++ b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/StudiesSpec.groovy
@@ -169,26 +169,4 @@ class StudiesSpec extends RESTSpec {
         assert studyResponse2.studies*.studyId.sort() == [SHARED_CONCEPTS_A_ID, SHARED_CONCEPTS_RESTRICTED_ID].sort()
     }
 
-    /**
-     *  given: "Shared concepts study is loaded with the default tabular representation"
-     *  when: "I try to fetch study A by studyId"
-     *  then: "the study object is returned with the defaultTabularRepresentation metadata
-     */
-    def "default tabular representation for a study is fetched by study name"() {
-        given: "Shared concepts studies are loaded and I do have limited access"
-
-        when: "I try to fetch study A by studyId"
-        def studyResponse = get([
-                path      : "${PATH_STUDIES}/studyId/${SHARED_CONCEPTS_A_ID}",
-                acceptType: JSON,
-        ])
-        def metadata = studyResponse.metadata
-
-        then: "the study object is returned with the defaultTabularRepresentation metadata"
-        assert studyResponse.studyId == SHARED_CONCEPTS_A_ID
-        assert metadata != null
-        assert metadata.defaultTabularRepresentation.rowDimensions == ['patient', "study"]
-        assert metadata.defaultTabularRepresentation.columnDimensions == ['concept']
-
-    }
 }


### PR DESCRIPTION
There are still 3 tests failing because of the broken EHR test study:
- ["query observations based on time constraint between startDates"](https://github.com/thehyve/transmart-core/blob/d783b7b58287481324ddcfa5a683693c8b84dfa1/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/TimeConstraintSpec.groovy#L69)
- [ "SubSelectionConstraint.class"](https://github.com/thehyve/transmart-core/blob/69fb80c24b68425243559e676ed4cd2477710b9b/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/hypercube/ConstraintSpec.groovy#L418)
- ["supported fields"](https://github.com/thehyve/transmart-core/blob/d783b7b58287481324ddcfa5a683693c8b84dfa1/transmart-rest-api-e2e/src/test/groovy/tests/rest/v2/SupportedFieldsSpec.groovy#L20)