### PR TITLE
Fix invalid constraint rewrite rule.

### DIFF
--- a/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/query/NormaliseConstraintRewriter.groovy
+++ b/transmart-core-api/src/main/groovy/org/transmartproject/core/multidimquery/query/NormaliseConstraintRewriter.groovy
@@ -15,12 +15,12 @@ import groovy.transform.CompileStatic
 class NormaliseConstraintRewriter extends ConstraintRewriter {
 
     /**
-     * Eliminate subselect true
+     * Eliminate subselect true for patient dimension.
      */
     @Override
     Constraint build(SubSelectionConstraint constraint) {
         Constraint subconstraint = build(constraint.constraint)
-        if (subconstraint instanceof TrueConstraint) {
+        if (constraint.dimension == 'patient' && subconstraint instanceof TrueConstraint) {
             return subconstraint
         } else {
             return new SubSelectionConstraint(constraint.dimension, subconstraint)

--- a/transmart-core-db/src/test/groovy/org/transmartproject/db/multidimquery/QueryRewriterSpec.groovy
+++ b/transmart-core-db/src/test/groovy/org/transmartproject/db/multidimquery/QueryRewriterSpec.groovy
@@ -238,6 +238,17 @@ class QueryRewriterSpec extends Specification {
         result.toJson() == expected.toJson()
     }
 
+    void 'test rewriting of non-patient dimension subselect with true subconstraint'() {
+        given: 'a subselect constraint for non-patient dimension'
+        Constraint constraint = new SubSelectionConstraint('sample', new TrueConstraint())
+
+        when: 'rewriting the first constraint'
+        def result = new CombinationConstraintRewriter().build(constraint)
+
+        then: 'the rewrite result is equal to the original'
+        result.toJson() == constraint.toJson()
+    }
+
     void 'test rewriting of conjunction with subselect with true subconstraint'() {
         given: 'two logically equivalent constraints, the second form preferred'
         Constraint constraint = new AndConstraint([


### PR DESCRIPTION
The rule is not valid when the subselection dimension is
different from its parent dimension.