### PR TITLE
Ensure audience validation on access token

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ ext {
     quartzVersion = '2.0.13'
     springSecurityPluginVersion = '3.1.1'
     springSecurityVersion = '3.2.3.RELEASE'
+    keycloakVersion = '6.0.1'
 }
 
 task wrapper(type: Wrapper) {

--- a/docker/transmart-api-server/docker-entrypoint.sh
+++ b/docker/transmart-api-server/docker-entrypoint.sh
@@ -54,6 +54,7 @@ keycloak:
     auth-server-url: ${KEYCLOAK_SERVER_URL}/auth
     resource: ${KEYCLOAK_CLIENT_ID}
     use-resource-role-mappings: true
+    verify-token-audience: true
 EndOfMessage
 sync
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ keycloak:
     auth-server-url: https://keycloak-dwh-test.thehyve.net/auth
     resource: transmart-client
     use-resource-role-mappings: true
+    verify-token-audience: true
 ```
 
 When `denyAccessToUsersWithoutRole` is set to `true`, users are not allowed to access any data, including

--- a/transmart-api-server/README.md
+++ b/transmart-api-server/README.md
@@ -37,6 +37,9 @@ Login to `https://idp.example.com/auth/admin/` and:
     - Valid Redirect URIs: `https://glowingbear.example.com`
     - Web Origins: `https://glowingbear.example.com`
 
+    **Note:**For Keycloak versions > 4.5.0 configure client mappers to include client ID in the aud (audience) Claim 
+    by following [the official instruction](https://www.keycloak.org/docs/4.8/server_admin/#_audience_hardcoded).
+
 3. Create Roles.  
     **Note:** not realm roles, but client roles.
     Follow `Clients > Roles` (tab)
@@ -111,6 +114,7 @@ keycloak:
     realm: {dev}
     bearer-only: true
     use-resource-role-mappings: true
+    verify-token-audience: true
 
 # to enable use of keycloak API to fetch list of users for jobs
 keycloakOffline:

--- a/transmart-api-server/build.gradle
+++ b/transmart-api-server/build.gradle
@@ -1,3 +1,10 @@
+dependencyManagement {
+    imports {
+        mavenBom "org.keycloak.bom:keycloak-adapter-bom:${keycloakVersion}"
+    }
+    applyMavenExclusions false
+}
+
 dependencies {
     //Grails 3 dependencies
     compile "org.springframework.boot:spring-boot-starter-logging"
@@ -32,7 +39,7 @@ dependencies {
     compile project(':transmart-rest-api')
     compile project(':transmart-schemas')
 
-    compile "org.keycloak:keycloak-spring-boot-starter:4.0.0.Final"
+    compile "org.keycloak:keycloak-legacy-spring-boot-starter"
     compile "org.springframework.boot:spring-boot-starter-security"
 
     testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'

--- a/transmart-api-server/grails-app/conf/application.yml
+++ b/transmart-api-server/grails-app/conf/application.yml
@@ -92,6 +92,7 @@ environments:
             auth-server-url: http://localhost:8080/auth
             resource: transmart
             use-resource-role-mappings: true
+            verify-token-audience: true
     development:
         keycloak:
             realm: dev
@@ -99,6 +100,7 @@ environments:
             auth-server-url: http://localhost:8080/auth
             resource: transmart
             use-resource-role-mappings: true
+            verify-token-audience: true
 #            disable-trust-manager: false  # when true, SSL certificate checking is disabled. Do not use that in production!
 
 #        keycloakOffline:


### PR DESCRIPTION
According to OIDC specification: "The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience."

Related ticket: [TMT-383](https://jira.thehyve.nl/browse/TMT-838)