### PR TITLE
Fix creating patient sets based on patient mapping identifiers.

### DIFF
--- a/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/PatientSetService.groovy
+++ b/transmart-core-db/grails-app/services/org/transmartproject/db/clinical/PatientSetService.groovy
@@ -563,7 +563,7 @@ class PatientSetService extends AbstractDataResourceService implements PatientSe
                       where p.result_instance_id = ?
                       and p.patient_num in (
                           select pm.patient_num
-                          from patient_mapping pm
+                          from i2b2demodata.patient_mapping pm
                           inner join subject_ids si on pm.patient_ide = si.patient_ide)''')
             query.setLong(1, patientSet.id)
             def rs = query.executeQuery()


### PR DESCRIPTION
When creating a patient set with `subjectIds` (identifiers in the patient mapping table), the API server fails on unknown relation `patient_mapping` when running with Docker and Liquibase.
This change fixes the issue.